### PR TITLE
Develop flexible updates for Solr schema #46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>8.4.1</version>
+            <version>8.5.1</version>
         </dependency>
         <!-- SolrJ needs it -->
         <dependency>

--- a/src/main/java/gov/nasa/pds/registry/mgr/Constants.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/Constants.java
@@ -2,5 +2,5 @@ package gov.nasa.pds.registry.mgr;
 
 public interface Constants
 {
-    public static final String REGISTRY_COLLECTION = "registry";
+    public static final String DEFAULT_REGISTRY_COLLECTION = "registry";
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -163,12 +163,6 @@ public class RegistryManagerCli
         bld = Option.builder("solrUrl").hasArg().argName("url");
         options.addOption(bld.build());
 
-        bld = Option.builder("shards").hasArg().argName("#");
-        options.addOption(bld.build());
-
-        bld = Option.builder("replicas").hasArg().argName("#");
-        options.addOption(bld.build());
-        
         bld = Option.builder("filePath").hasArg().argName("path");
         options.addOption(bld.build());
 
@@ -192,6 +186,16 @@ public class RegistryManagerCli
         options.addOption(bld.build());
         
         bld = Option.builder("all");
+        options.addOption(bld.build());
+        
+        // Create update collection
+        bld = Option.builder("collection").hasArg().argName("name");
+        options.addOption(bld.build());
+
+        bld = Option.builder("shards").hasArg().argName("#");
+        options.addOption(bld.build());
+
+        bld = Option.builder("replicas").hasArg().argName("#");
         options.addOption(bld.build());
     }
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -17,6 +17,7 @@ import gov.nasa.pds.registry.mgr.cmd.DeleteRegistryCmd;
 import gov.nasa.pds.registry.mgr.cmd.ExportFileCmd;
 import gov.nasa.pds.registry.mgr.cmd.GenerateSolrSchemaCmd;
 import gov.nasa.pds.registry.mgr.cmd.LoadDataCmd;
+import gov.nasa.pds.registry.mgr.cmd.UpdateSolrSchemaCmd;
 import gov.nasa.pds.registry.mgr.util.ExceptionUtils;
 
 
@@ -43,17 +44,18 @@ public class RegistryManagerCli
         System.out.println("Commands:");
         System.out.println();
         System.out.println("Registry:");
-        System.out.println("  load-data          Load data into registry collection");
-        System.out.println("  delete-data        Delete data from registry collection");
-        System.out.println("  export-file        Export a file from blob storage");
-        System.out.println("  create-registry    Create registry collection");
-        System.out.println("  delete-registry    Delete registry collection and all its data");
+        System.out.println("  load-data        Load data into registry collection");
+        System.out.println("  delete-data      Delete data from registry collection");
+        System.out.println("  export-file      Export a file from blob storage");
+        System.out.println("  create-registry  Create registry collection");
+        System.out.println("  delete-registry  Delete registry collection and all its data");
         System.out.println();
         System.out.println("Search:");
         System.out.println("  generate-solr-schema  Generate Solr schema from one or more PDS data dictionaries");        
+        System.out.println("  update-solr-schema    Update Solr schema from one or more PDS data dictionaries");
         System.out.println();
         System.out.println("Options:");
-        System.out.println("  -help              Print help for a command");
+        System.out.println("  -help  Print help for a command");
         
         System.out.println();
         System.out.println("Pass -help after any command to see command-specific usage information, for example,");
@@ -145,6 +147,7 @@ public class RegistryManagerCli
         commands.put("create-registry", new CreateRegistryCmd());
         commands.put("delete-registry", new DeleteRegistryCmd());
         commands.put("generate-solr-schema", new GenerateSolrSchemaCmd());
+        commands.put("update-solr-schema", new UpdateSolrSchemaCmd());
     }
     
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -109,7 +109,7 @@ public class RegistryManagerCli
         }
         catch(Exception ex)
         {
-            System.out.println("ERROR: " + ExceptionUtils.getMessage(ex));
+            System.out.println("[ERROR] " + ExceptionUtils.getMessage(ex));
             return false;
         }
         
@@ -127,20 +127,20 @@ public class RegistryManagerCli
             String[] args = cmdLine.getArgs();
             if(args == null || args.length == 0)
             {
-                System.out.println("ERROR: Missing command.");
+                System.out.println("[ERROR] Missing command.");
                 return false;
             }
 
             if(args.length > 1)
             {
-                System.out.println("ERROR: Invalid command: " + String.join(" ", args)); 
+                System.out.println("[ERROR] Invalid command: " + String.join(" ", args)); 
                 return false;
             }
             
             this.command = commands.get(args[0]);
             if(this.command == null)
             {
-                System.out.println("ERROR: Invalid command: " + args[0]);
+                System.out.println("[ERROR] Invalid command: " + args[0]);
                 return false;
             }
             
@@ -148,7 +148,7 @@ public class RegistryManagerCli
         }
         catch(ParseException ex)
         {
-            System.out.println("ERROR: " + ex.getMessage());
+            System.out.println("[ERROR] " + ex.getMessage());
             return false;
         }
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -19,6 +19,7 @@ import gov.nasa.pds.registry.mgr.cmd.GenerateSolrSchemaCmd;
 import gov.nasa.pds.registry.mgr.cmd.LoadDataCmd;
 import gov.nasa.pds.registry.mgr.cmd.UpdateSolrSchemaCmd;
 import gov.nasa.pds.registry.mgr.util.ExceptionUtils;
+import gov.nasa.pds.registry.mgr.util.log.Log4jConfigurator;
 
 
 public class RegistryManagerCli
@@ -65,12 +66,14 @@ public class RegistryManagerCli
         
     public void run(String[] args)
     {
+        // Print help if there are no command line parameters
         if(args.length == 0)
         {
             printHelp();
             System.exit(1);
         }
 
+        // Parse command line arguments
         if(!parse(args))
         {
             System.out.println();
@@ -78,6 +81,10 @@ public class RegistryManagerCli
             System.exit(1);
         }
 
+        // Init logger
+        initLogger();
+        
+        // Run command
         if(!runCommand())
         {
             System.exit(1);
@@ -85,6 +92,15 @@ public class RegistryManagerCli
     }
 
 
+    private void initLogger()
+    {
+        String verbosity = cmdLine.getOptionValue("v", "1");
+        String logFile = cmdLine.getOptionValue("log");
+
+        Log4jConfigurator.configure(verbosity, logFile);
+    }
+
+    
     private boolean runCommand()
     {
         try
@@ -199,6 +215,13 @@ public class RegistryManagerCli
         options.addOption(bld.build());
 
         bld = Option.builder("replicas").hasArg().argName("#");
+        options.addOption(bld.build());
+        
+        // Logger
+        bld = Option.builder("log").hasArg().argName("file");
+        options.addOption(bld.build());
+        
+        bld = Option.builder("v").hasArg().argName("level");
         options.addOption(bld.build());
     }
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
@@ -42,9 +42,7 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println("Collection: " + collectionName);
         System.out.println("Shards: " + shards);
         System.out.println("Replicas: " + replicas);
-        System.out.println();
 
-        
         ZkClientClusterStateProvider zk = null;
         CloudSolrClient client = null;
         try

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
@@ -31,6 +31,7 @@ public class CreateRegistryCmd implements CliCommand
         String zkHost = cmdLine.getOptionValue("zkHost", "localhost:9983");
         File configDir = getConfigDir(cmdLine.getOptionValue("configDir"));
         
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
         int shards = parseShards(cmdLine.getOptionValue("shards", "1"));
         int replicas = parseReplicas(cmdLine.getOptionValue("replicas", "1"));
         
@@ -38,6 +39,7 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println();
         System.out.println("ZooKeeper host: " + zkHost);
         System.out.println("Configuration directory: " + configDir.getAbsolutePath());
+        System.out.println("Collection: " + collectionName);
         System.out.println("Shards: " + shards);
         System.out.println("Replicas: " + replicas);
         System.out.println();
@@ -49,12 +51,12 @@ public class CreateRegistryCmd implements CliCommand
         {
             System.out.println("Uploading configuration...");
             zk = new ZkClientClusterStateProvider(zkHost);
-            zk.uploadConfig(configDir.toPath(), Constants.REGISTRY_COLLECTION);
+            zk.uploadConfig(configDir.toPath(), collectionName);
     
             System.out.println("Creating collection...");
             client = new CloudSolrClient.Builder(zk).build();
             CollectionAdminRequest.Create req = CollectionAdminRequest.Create
-                    .createCollection(Constants.REGISTRY_COLLECTION, Constants.REGISTRY_COLLECTION, 1, 1);
+                    .createCollection(collectionName, collectionName, 1, 1);
 
             @SuppressWarnings("unused")
             CollectionAdminResponse resp = req.process(client);
@@ -141,6 +143,7 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println("                      Default value is localhost:9983");
         System.out.println("  -configDir <dir>    Configuration directory with registry collection configuration files"); 
         System.out.println("                      Default value is $REGISTRY_MANAGER_HOME/solr/collections/registry");
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
         System.out.println("  -shards <number>    Number of shards for registry collection. Default value is 1");
         System.out.println("  -replicas <number>  Number of replicas for registry collection. Default value is 1");
         System.out.println();

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/DeleteDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/DeleteDataCmd.java
@@ -26,6 +26,8 @@ public class DeleteDataCmd implements CliCommand
             return;
         }
 
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        
         String query = buildSolrQuery(cmdLine);
         if(query == null)
         {
@@ -43,14 +45,14 @@ public class DeleteDataCmd implements CliCommand
             // I could not find a way to get number of deleted docs from a delete query.
             SolrQuery solrQuery = new SolrQuery(query);
             solrQuery.setRows(0);
-            QueryResponse resp = client.query(Constants.REGISTRY_COLLECTION, solrQuery);
+            QueryResponse resp = client.query(collectionName, solrQuery);
             long numDocs = resp.getResults().getNumFound();
             
             // Run delete command
             if(numDocs > 0)
             {
-                client.deleteByQuery(Constants.REGISTRY_COLLECTION, query);
-                client.commit(Constants.REGISTRY_COLLECTION);
+                client.deleteByQuery(collectionName, query);
+                client.commit(collectionName);
             }
             
             System.out.println("Deleted " + numDocs + " document(s)");
@@ -98,14 +100,16 @@ public class DeleteDataCmd implements CliCommand
         System.out.println();
         System.out.println("Delete data from registry collection");
         System.out.println();
-        System.out.println("Options:");
-        System.out.println("  -lidvid <id>     Delete data by lidvid");
-        System.out.println("  -lid <id>        Delete data by lid");
-        System.out.println("  -packageId <id>  Delete data by package id"); 
-        System.out.println("  -all             Delete all data");
-        System.out.println("  -solrUrl <url>   Solr URL. Default is http://localhost:8983/solr");
-        System.out.println("  -zkHost <host>   ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                   For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("Required parameters, one of:");
+        System.out.println("  -lidvid <id>        Delete data by lidvid");
+        System.out.println("  -lid <id>           Delete data by lid");
+        System.out.println("  -packageId <id>     Delete data by package id"); 
+        System.out.println("  -all                Delete all data");
+        System.out.println("Optional parameters:");
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr");
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/DeleteRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/DeleteRegistryCmd.java
@@ -30,9 +30,8 @@ public class DeleteRegistryCmd implements CliCommand
         }
         
         String zkHost = cmdLine.getOptionValue("zkHost", "localhost:9983");
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
 
-        System.out.println("Deleting registry collection");
-        System.out.println();
         System.out.println("ZooKeeper host: " + zkHost);
 
         ZkClientClusterStateProvider zk = null;
@@ -42,8 +41,8 @@ public class DeleteRegistryCmd implements CliCommand
             zk = new ZkClientClusterStateProvider(zkHost);
             client = new CloudSolrClient.Builder(zk).build();
             
-            deleteCollection(client);
-            deleteConfigSet(client);
+            deleteCollection(client, collectionName);
+            deleteConfigSet(client, collectionName);
         }
         finally
         {
@@ -53,10 +52,10 @@ public class DeleteRegistryCmd implements CliCommand
     }
 
     
-    private void deleteCollection(CloudSolrClient client)
+    private void deleteCollection(CloudSolrClient client, String collectionName)
     {
-        System.out.println("Deleting collection...");
-        CollectionAdminRequest.Delete req = CollectionAdminRequest.Delete.deleteCollection(Constants.REGISTRY_COLLECTION);
+        System.out.println("Deleting collection " + collectionName + "...");
+        CollectionAdminRequest.Delete req = CollectionAdminRequest.Delete.deleteCollection(collectionName);
         
         try
         {
@@ -70,11 +69,11 @@ public class DeleteRegistryCmd implements CliCommand
     }
     
 
-    private void deleteConfigSet(CloudSolrClient client)
+    private void deleteConfigSet(CloudSolrClient client, String collectionName)
     {
-        System.out.println("Deleting configset...");
+        System.out.println("Deleting configset " + collectionName + "...");
         ConfigSetAdminRequest.Delete req = new ConfigSetAdminRequest.Delete();
-        req.setConfigSetName(Constants.REGISTRY_COLLECTION);
+        req.setConfigSetName(collectionName);
         
         try
         {
@@ -97,9 +96,10 @@ public class DeleteRegistryCmd implements CliCommand
         System.out.println("Delete registry collection and all its data");
         System.out.println();
         System.out.println("Optional parameters:");
-        System.out.println("  -zkHost <host>  ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                  For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
-        System.out.println("                  Default value is localhost:9983");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("                      Default value is localhost:9983");
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
     }
 
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportFileCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportFileCmd.java
@@ -26,6 +26,9 @@ public class ExportFileCmd implements CliCommand
             return;
         }
         
+        // Collection name
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        
         // Lidvid
         String lidvid = cmdLine.getOptionValue("lidvid");
         if(lidvid == null) 
@@ -53,7 +56,7 @@ public class ExportFileCmd implements CliCommand
         try
         {
             // Get Solr doc by lidvid
-            QueryResponse resp = client.query(Constants.REGISTRY_COLLECTION, solrQuery);
+            QueryResponse resp = client.query(collectionName, solrQuery);
             long numDocs = resp.getResults().getNumFound();
             if(numDocs == 0)
             {
@@ -93,12 +96,13 @@ public class ExportFileCmd implements CliCommand
         System.out.println("Export a file from blob storage");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -lidvid <id>      Lidvid of a file to export from blob storage.");
-        System.out.println("  -filePath <path>  A path to a file to write."); 
+        System.out.println("  -lidvid <id>        Lidvid of a file to export from blob storage.");
+        System.out.println("  -filePath <path>    A path to a file to write."); 
         System.out.println("Optional parameters:");
-        System.out.println("  -solrUrl <url>    Solr URL. Default is http://localhost:8983/solr");
-        System.out.println("  -zkHost <host>    ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                    For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr");
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
@@ -58,13 +58,9 @@ public class GenerateSolrSchemaCmd implements CliCommand
         System.out.println("Generate Solr schema from one or more PDS data dictionaries.");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -config <path>      Configuration file.");
+        System.out.println("  -config <path>  Configuration file.");
         System.out.println("Optional parameters:");
-        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
-        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
-        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
-        System.out.println("  -outDir <dir>       Output directory for Solr schema file. Default value is '/tmp'."); 
+        System.out.println("  -outDir <dir>   Output directory for Solr schema file. Default value is '/tmp'."); 
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
@@ -4,18 +4,24 @@ import java.io.File;
 import java.io.FileWriter;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import gov.nasa.pds.registry.mgr.schema.SolrSchemaGenerator;
 import gov.nasa.pds.registry.mgr.schema.cfg.ConfigReader;
 import gov.nasa.pds.registry.mgr.schema.cfg.Configuration;
 import gov.nasa.pds.registry.mgr.schema.dd.DataDictionary;
 import gov.nasa.pds.registry.mgr.schema.dd.JsonDDParser;
+import gov.nasa.pds.registry.mgr.util.log.RegistryLogManager;
 
 
 public class GenerateSolrSchemaCmd implements CliCommand
 {
+    private Logger LOG;
+    
     public GenerateSolrSchemaCmd()
     {
+        // NOTE: Do not get logger here. It is not initialized yet!
     }
     
     
@@ -38,15 +44,25 @@ public class GenerateSolrSchemaCmd implements CliCommand
             return;
         }
         
+        // NOTE: Do not get logger in constructor or static initializer!
+        LOG = LogManager.getLogger(getClass());
+        // This logger does not depend on -v (verbosity) command line parameter.
+        Logger minLogger = RegistryLogManager.getMinInfoLogger();
+        
+        // Read configuration file
+        File cfgFile = new File(cfgPath);
+        minLogger.info("Reading configuration from " + cfgFile.getAbsolutePath());
         ConfigReader cfgReader = new ConfigReader();
-        Configuration cfg = cfgReader.read(new File(cfgPath));
+        Configuration cfg = cfgReader.read(cfgFile);
         
         // Get output folder
-        File outDir = new File(cmdLine.getOptionValue("outDir", "/tmp"));
+        File outDir = new File(cmdLine.getOptionValue("outDir", "/tmp/registry"));
         outDir.mkdirs();
         
         // Generate Solr schema
         generateSolrSchema(cfg, outDir);
+        
+        minLogger.info("Done.");
     }
 
     
@@ -60,7 +76,9 @@ public class GenerateSolrSchemaCmd implements CliCommand
         System.out.println("Required parameters:");
         System.out.println("  -config <path>  Configuration file.");
         System.out.println("Optional parameters:");
-        System.out.println("  -outDir <dir>   Output directory for Solr schema file. Default value is '/tmp'."); 
+        System.out.println("  -outDir <dir>   Output directory for Solr schema file. Default value is '/tmp/registry'.");
+        System.out.println("  -log <file>     Log file. Default is /tmp/registry/registry.log.");
+        System.out.println("  -v <level>      Logger verbosity: 0=Debug, 1=Info (default), 2=Warning, 3=Error.");
         System.out.println();
     }
 
@@ -68,12 +86,16 @@ public class GenerateSolrSchemaCmd implements CliCommand
     private void generateSolrSchema(Configuration cfg, File outDir) throws Exception
     {
         File outFile = new File(outDir, "solr-fields.xml");
+        LOG.info("Writing Solr fields to " + outFile.getAbsolutePath());
+        
         FileWriter writer = new FileWriter(outFile);
+        writer.write("<fields>\n");
         
         SolrSchemaGenerator gen = new SolrSchemaGenerator(cfg, writer);
         
         for(File file: cfg.dataDicFiles)
         {
+            LOG.info("Processing data dictionary " + file.getAbsolutePath());
             JsonDDParser parser = new JsonDDParser(file);
             DataDictionary dd = parser.parse();
             parser.close();
@@ -81,6 +103,7 @@ public class GenerateSolrSchemaCmd implements CliCommand
             gen.generateSolrSchema(dd);
         }
         
+        writer.write("</fields>\n");
         writer.close();
     }
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/GenerateSolrSchemaCmd.java
@@ -58,9 +58,13 @@ public class GenerateSolrSchemaCmd implements CliCommand
         System.out.println("Generate Solr schema from one or more PDS data dictionaries.");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -config <path>  Configuration file.");
-        System.out.println("Optional parameters:");        
-        System.out.println("  -outDir <dir>   Output directory for Solr schema file. Default value is '/tmp'."); 
+        System.out.println("  -config <path>      Configuration file.");
+        System.out.println("Optional parameters:");
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
+        System.out.println("  -outDir <dir>       Output directory for Solr schema file. Default value is '/tmp'."); 
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/LoadDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/LoadDataCmd.java
@@ -36,6 +36,9 @@ public class LoadDataCmd implements CliCommand
             return;
         }
 
+        // Solr collection name
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+
         // Get list of files to load
         String filePath = cmdLine.getOptionValue("filePath");
         if(filePath == null) 
@@ -55,7 +58,7 @@ public class LoadDataCmd implements CliCommand
         {
             for(File file: files)
             {
-                loadFile(client, file);
+                loadFile(client, collectionName, file);
             }
             
             System.out.println("Done");
@@ -129,17 +132,17 @@ public class LoadDataCmd implements CliCommand
     }
     
     
-    private void loadFile(SolrClient client, File file) throws Exception
+    private void loadFile(SolrClient client, String collectionName, File file) throws Exception
     {
         System.out.println("Loading file: " + file.getAbsolutePath());
         
         ContentStreamUpdateRequest req = new ContentStreamUpdateRequest("/update");
-        req.setParam(CollectionAdminParams.COLLECTION, Constants.REGISTRY_COLLECTION);
+        req.setParam(CollectionAdminParams.COLLECTION, collectionName);
         req.setMethod(SolrRequest.METHOD.POST);
         req.addFile(file, XML_CTX_TYPE);
 
         req.process(client);
-        client.commit(Constants.REGISTRY_COLLECTION);
+        client.commit(collectionName);
     }
     
     
@@ -150,11 +153,13 @@ public class LoadDataCmd implements CliCommand
         System.out.println();
         System.out.println("Load data into registry collection");
         System.out.println();
-        System.out.println("Options:");
-        System.out.println("  -filePath <path>  An XML file or a directory to load. This is a required parameter."); 
-        System.out.println("  -solrUrl <url>    Solr URL. Default is http://localhost:8983/solr");
-        System.out.println("  -zkHost <host>    ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                    For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("Required parameters:");
+        System.out.println("  -filePath <path>    An XML file or a directory to load."); 
+        System.out.println("Optional parameters:");
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
@@ -3,6 +3,8 @@ package gov.nasa.pds.registry.mgr.cmd;
 import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
 
 import gov.nasa.pds.registry.mgr.Constants;
@@ -12,18 +14,25 @@ import gov.nasa.pds.registry.mgr.schema.cfg.Configuration;
 import gov.nasa.pds.registry.mgr.schema.dd.DataDictionary;
 import gov.nasa.pds.registry.mgr.schema.dd.JsonDDParser;
 import gov.nasa.pds.registry.mgr.util.SolrUtils;
+import gov.nasa.pds.registry.mgr.util.log.RegistryLogManager;
 
 
 public class UpdateSolrSchemaCmd implements CliCommand
 {
+    private Logger LOG;
+    
     public UpdateSolrSchemaCmd()
     {
+        // NOTE: Do not get logger here. It is not initialized yet!
     }
     
     
     @Override
     public void run(CommandLine cmdLine) throws Exception
     {
+        // NOTE: Do not get logger in constructor or static initializer!
+        LOG = LogManager.getLogger(getClass());
+        
         if(cmdLine.hasOption("help"))
         {
             printHelp();
@@ -39,15 +48,21 @@ public class UpdateSolrSchemaCmd implements CliCommand
             return;
         }
         
+        // This logger does not depend on -v (verbosity) command line parameter.
+        Logger minLogger = RegistryLogManager.getMinInfoLogger();
+        
         // Read configuration file
+        File cfgFile = new File(cfgPath);
+        minLogger.info("Reading configuration from " + cfgFile.getAbsolutePath());
         ConfigReader cfgReader = new ConfigReader();
-        Configuration cfg = cfgReader.read(new File(cfgPath));
+        Configuration cfg = cfgReader.read(cfgFile);
         
         SolrClient client = SolrUtils.createSolrClient(cmdLine);
-        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        String solrCollection = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        LOG.info("Solr collection: " + solrCollection);
         
         // Update Solr schema
-        updateSolrSchema(cfg, client, collectionName);
+        updateSolrSchema(cfg, client, solrCollection);
     }
 
     
@@ -65,6 +80,8 @@ public class UpdateSolrSchemaCmd implements CliCommand
         System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
         System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
         System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
+        System.out.println("  -log <file>         Log file. Default is /tmp/registry/registry.log.");
+        System.out.println("  -v <level>          Logger verbosity: 0=Debug, 1=Info (default), 2=Warning, 3=Error.");
         System.out.println();
     }
 
@@ -75,7 +92,7 @@ public class UpdateSolrSchemaCmd implements CliCommand
         
         for(File file: cfg.dataDicFiles)
         {
-            System.out.println("Processing data dictionary " + file.getAbsolutePath());
+            LOG.info("Processing data dictionary " + file.getAbsolutePath());
             JsonDDParser parser = new JsonDDParser(file);
             DataDictionary dd = parser.parse();
             parser.close();

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
@@ -1,0 +1,86 @@
+package gov.nasa.pds.registry.mgr.cmd;
+
+import java.io.File;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.solr.client.solrj.SolrClient;
+
+import gov.nasa.pds.registry.mgr.Constants;
+import gov.nasa.pds.registry.mgr.schema.SolrSchemaUpdater;
+import gov.nasa.pds.registry.mgr.schema.cfg.ConfigReader;
+import gov.nasa.pds.registry.mgr.schema.cfg.Configuration;
+import gov.nasa.pds.registry.mgr.schema.dd.DataDictionary;
+import gov.nasa.pds.registry.mgr.schema.dd.JsonDDParser;
+import gov.nasa.pds.registry.mgr.util.SolrUtils;
+
+
+public class UpdateSolrSchemaCmd implements CliCommand
+{
+    public UpdateSolrSchemaCmd()
+    {
+    }
+    
+    
+    @Override
+    public void run(CommandLine cmdLine) throws Exception
+    {
+        if(cmdLine.hasOption("help"))
+        {
+            printHelp();
+            return;
+        }
+
+        String cfgPath = cmdLine.getOptionValue("config");
+        if(cfgPath == null) 
+        {
+            System.out.println("ERROR: Missing required parameter '-config'");
+            System.out.println();
+            printHelp();
+            return;
+        }
+        
+        // Read configuration file
+        ConfigReader cfgReader = new ConfigReader();
+        Configuration cfg = cfgReader.read(new File(cfgPath));
+        
+        SolrClient client = SolrUtils.createSolrClient(cmdLine);
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        
+        // Update Solr schema
+        updateSolrSchema(cfg, client, collectionName);
+    }
+
+    
+    public void printHelp()
+    {
+        System.out.println("Usage: registry-manager update-solr-schema <options>");
+
+        System.out.println();
+        System.out.println("Update Solr schema from one or more PDS data dictionaries.");
+        System.out.println();
+        System.out.println("Required parameters:");
+        System.out.println("  -config <path>      Configuration file.");
+        System.out.println("Optional parameters:");
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
+        System.out.println();
+    }
+
+    
+    private void updateSolrSchema(Configuration cfg, SolrClient client, String collectionName) throws Exception
+    {
+        SolrSchemaUpdater upd = new SolrSchemaUpdater(cfg, client, collectionName);
+        
+        for(File file: cfg.dataDicFiles)
+        {
+            System.out.println("Processing data dictionary " + file.getAbsolutePath());
+            JsonDDParser parser = new JsonDDParser(file);
+            DataDictionary dd = parser.parse();
+            parser.close();
+            
+            upd.updateSolrSchema(dd);
+        }
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
@@ -30,9 +30,6 @@ public class UpdateSolrSchemaCmd implements CliCommand
     @Override
     public void run(CommandLine cmdLine) throws Exception
     {
-        // NOTE: Do not get logger in constructor or static initializer!
-        LOG = LogManager.getLogger(getClass());
-        
         if(cmdLine.hasOption("help"))
         {
             printHelp();
@@ -47,7 +44,9 @@ public class UpdateSolrSchemaCmd implements CliCommand
             printHelp();
             return;
         }
-        
+
+        // NOTE: Do not get logger in constructor or static initializer!
+        LOG = LogManager.getLogger(getClass());
         // This logger does not depend on -v (verbosity) command line parameter.
         Logger minLogger = RegistryLogManager.getMinInfoLogger();
         

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/UpdateSolrSchemaCmd.java
@@ -63,6 +63,8 @@ public class UpdateSolrSchemaCmd implements CliCommand
         
         // Update Solr schema
         updateSolrSchema(cfg, client, solrCollection);
+        
+        minLogger.info("Done.");
     }
 
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
@@ -189,6 +189,8 @@ public class SolrSchemaUpdater
     {
         if(existingFieldNames.contains(name)) return;
         
+        existingFieldNames.add(name);
+        
         // Create add field request to the batch
         batch.add(SolrUtils.createAddFieldRequest(name, type));
         totalCount++;

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
@@ -1,0 +1,159 @@
+package gov.nasa.pds.registry.mgr.schema;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.solr.client.solrj.SolrClient;
+
+import gov.nasa.pds.registry.mgr.schema.cfg.Configuration;
+import gov.nasa.pds.registry.mgr.schema.dd.DDAttr;
+import gov.nasa.pds.registry.mgr.schema.dd.DDClass;
+import gov.nasa.pds.registry.mgr.schema.dd.DataDictionary;
+import gov.nasa.pds.registry.mgr.schema.dd.Pds2SolrDataTypeMap;
+import gov.nasa.pds.registry.mgr.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.util.SolrUtils;
+
+
+public class SolrSchemaUpdater
+{
+    private Configuration cfg;
+    private Pds2SolrDataTypeMap dtMap;
+    private SolrClient solrClient;
+    private String solrCollectionName;
+    private Set<String> existingFieldNames;
+    
+    private int totalCount;
+    private int lastBatchCount;
+    private int batchSize = 100;
+    
+    
+    public SolrSchemaUpdater(Configuration cfg, SolrClient solrClient, String solrCollectionName) throws Exception
+    {
+        this.cfg = cfg;
+        this.solrClient = solrClient;
+        this.solrCollectionName = solrCollectionName;
+        
+        // Load PDS to Solr data type mapping files
+        dtMap = loadDataTypeMap();
+        
+        // Get a list of existing field names from Solr
+        this.existingFieldNames = SolrUtils.getFieldNames(solrClient, solrCollectionName);
+    }
+
+
+    private Pds2SolrDataTypeMap loadDataTypeMap() throws Exception
+    {
+        Pds2SolrDataTypeMap map = new Pds2SolrDataTypeMap();
+        if(cfg.dataTypeFiles != null)
+        {
+            for(File file: cfg.dataTypeFiles)
+            {
+                System.out.println("Loading PDS to Solr data type mapping from " + file.getAbsolutePath());
+                map.load(file);
+            }
+        }
+        
+        return map;
+    }
+
+    
+    public void updateSolrSchema(DataDictionary dd) throws Exception
+    {
+        lastBatchCount = 0;
+        totalCount = 0;
+        
+        Map<String, String> attrId2Type = dd.getAttributeDataTypeMap();
+        Set<String> dataTypes = dd.getDataTypes();
+        
+        for(DDClass ddClass: dd.getClassMap().values())
+        {
+            // Skip type definitions.
+            if(dataTypes.contains(ddClass.nsName)) continue;
+            
+            // Apply class filters
+            if(cfg.includeClasses != null && cfg.includeClasses.size() > 0)
+            {
+                if(!cfg.includeClasses.contains(ddClass.nsName)) continue;
+            }
+            if(cfg.excludeClasses != null && cfg.excludeClasses.size() > 0)
+            {
+                if(cfg.excludeClasses.contains(ddClass.nsName)) continue;
+            }
+
+            File customFile = (cfg.customClassGens == null) ? null : cfg.customClassGens.get(ddClass.nsName);
+            if(customFile != null)
+            {
+                addCustomFields(ddClass, customFile);
+            }
+            else
+            {
+                addClassAttributes(ddClass, attrId2Type);
+            }
+        }
+        
+        finish();
+    }
+    
+    
+    private void addCustomFields(DDClass ddClass, File file) throws Exception
+    {
+        BufferedReader rd = null;
+        
+        try
+        {
+            rd = new BufferedReader(new FileReader(file));
+        }
+        catch(Exception ex)
+        {
+            throw new Exception("Could not open custom generator for class '" 
+                    + ddClass.nsName + "':  " + file.getAbsolutePath());
+        }
+        
+        try
+        {
+            String line;
+            while((line = rd.readLine()) != null)
+            {
+
+            }
+        }
+        finally
+        {
+            CloseUtils.close(rd);
+        }
+    }
+    
+    
+    private void addClassAttributes(DDClass ddClass, Map<String, String> attrId2Type) throws Exception
+    {
+        for(DDAttr attr: ddClass.attributes)
+        {
+            String pdsDataType = attrId2Type.get(attr.id);
+            if(pdsDataType == null) throw new Exception("No data type mapping for attribute " + attr.id);
+            
+            String fieldName = ddClass.nsName + "." + attr.nsName;
+            String solrDataType = dtMap.getSolrType(pdsDataType);
+            addSolrField(fieldName, solrDataType);
+        }
+    }
+
+    
+    private void addSolrField(String name, String type)
+    {
+        totalCount++;
+        if(totalCount % batchSize == 0)
+        {
+            System.out.println("Adding fields " + (lastBatchCount+1) + "-" + totalCount);
+            lastBatchCount = totalCount;
+        }
+    }
+    
+    
+    private void finish()
+    {
+        System.out.println("Adding fields " + (lastBatchCount+1) + "-" + totalCount);
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
@@ -75,7 +75,6 @@ public class SolrSchemaUpdater
         {
             for(File file: cfg.dataTypeFiles)
             {
-                LOG.info("Loading PDS to Solr data type mapping from " + file.getAbsolutePath());
                 map.load(file);
             }
         }
@@ -130,6 +129,7 @@ public class SolrSchemaUpdater
     
     private void addCustomFields(DDClass ddClass, File file) throws Exception
     {
+        LOG.info("Loading custom generator. Class = " + ddClass.nsName + ", file = " + file.getAbsolutePath());
         BufferedReader rd = null;
         
         try
@@ -147,7 +147,21 @@ public class SolrSchemaUpdater
             String line;
             while((line = rd.readLine()) != null)
             {
-
+                line = line.trim();
+                // Skip blank lines and comments
+                if(line.isEmpty() || line.startsWith("#")) continue;
+                
+                // Line format <field name> = <data type>
+                String tokens[] = line.split("=");
+                if(tokens.length != 2)
+                {
+                    throw new Exception("Invalid entry: " + line);
+                }
+                
+                String fieldName = tokens[0].trim();
+                String fieldType = tokens[1].trim();                
+                
+                addSolrField(fieldName, fieldType);
             }
         }
         finally

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/SolrSchemaUpdater.java
@@ -21,7 +21,10 @@ import gov.nasa.pds.registry.mgr.schema.dd.Pds2SolrDataTypeMap;
 import gov.nasa.pds.registry.mgr.util.CloseUtils;
 import gov.nasa.pds.registry.mgr.util.SolrUtils;
 
-
+/**
+ * Updates Solr schema by calling Solr schema API  
+ * @author karpenko
+ */
 public class SolrSchemaUpdater
 {
     private Logger LOG;
@@ -37,7 +40,13 @@ public class SolrSchemaUpdater
     private int lastBatchCount;
     private int batchSize = 100;
     
-    
+    /**
+     * Constructor 
+     * @param cfg Registry manager configuration
+     * @param solrClient Solr client
+     * @param solrCollectionName Solr collection name
+     * @throws Exception
+     */
     public SolrSchemaUpdater(Configuration cfg, SolrClient solrClient, String solrCollectionName) throws Exception
     {
         LOG = LogManager.getLogger(getClass());
@@ -54,6 +63,11 @@ public class SolrSchemaUpdater
     }
 
 
+    /**
+     * Load PDS to Solr data type map(s)
+     * @return
+     * @throws Exception
+     */
     private Pds2SolrDataTypeMap loadDataTypeMap() throws Exception
     {
         Pds2SolrDataTypeMap map = new Pds2SolrDataTypeMap();
@@ -70,6 +84,11 @@ public class SolrSchemaUpdater
     }
 
     
+    /**
+     * Add fields from data dictionary to Solr schema. Ignore existing fields.
+     * @param dd
+     * @throws Exception
+     */
     public void updateSolrSchema(DataDictionary dd) throws Exception
     {
         lastBatchCount = 0;
@@ -152,7 +171,7 @@ public class SolrSchemaUpdater
     }
 
     
-    private void addSolrField(String name, String type)
+    private void addSolrField(String name, String type) throws Exception
     {
         if(existingFieldNames.contains(name)) return;
         
@@ -164,19 +183,19 @@ public class SolrSchemaUpdater
         if(totalCount % batchSize == 0)
         {
             LOG.info("Adding fields " + (lastBatchCount+1) + "-" + totalCount);
-            // TODO: Call Schema API 
+            SolrUtils.multiUpdate(solrClient, solrCollectionName, batch);
             lastBatchCount = totalCount;
             batch.clear();
         }
     }
     
     
-    private void finish()
+    private void finish() throws Exception
     {
         if(batch.isEmpty()) return;
         
         LOG.info("Adding fields " + (lastBatchCount+1) + "-" + totalCount);
-        // TODO: Call Schema API
+        SolrUtils.multiUpdate(solrClient, solrCollectionName, batch);
         lastBatchCount = totalCount;
         batch.clear();
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/cfg/ConfigReader.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/cfg/ConfigReader.java
@@ -6,10 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.xml.xpath.XPathFactory;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -20,19 +16,13 @@ import gov.nasa.pds.registry.mgr.util.XmlDomUtils;
 
 public class ConfigReader
 {
-    private Logger LOG;
-    
-    XPathFactory xpf = XPathFactory.newInstance();
-    
     public ConfigReader()
     {
-        LOG = LogManager.getLogger(getClass());
     }
     
     
     public Configuration read(File file) throws Exception
     {
-        System.out.println("Reading configuration from " + file.getAbsolutePath());
         Document doc = XmlDomUtils.readXml(file);
         String rootElement = doc.getDocumentElement().getNodeName();
         if(!"schemaGen".equals(rootElement))

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/cfg/ConfigReader.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/cfg/ConfigReader.java
@@ -14,7 +14,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import gov.nasa.pds.registry.mgr.schema.dd.Pds2SolrDataTypeMap;
 import gov.nasa.pds.registry.mgr.util.XPathUtils;
 import gov.nasa.pds.registry.mgr.util.XmlDomUtils;
 
@@ -33,6 +32,7 @@ public class ConfigReader
     
     public Configuration read(File file) throws Exception
     {
+        System.out.println("Reading configuration from " + file.getAbsolutePath());
         Document doc = XmlDomUtils.readXml(file);
         String rootElement = doc.getDocumentElement().getNodeName();
         if(!"schemaGen".equals(rootElement))

--- a/src/main/java/gov/nasa/pds/registry/mgr/schema/dd/Pds2SolrDataTypeMap.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/schema/dd/Pds2SolrDataTypeMap.java
@@ -6,15 +6,20 @@ import java.io.FileReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import gov.nasa.pds.registry.mgr.util.CloseUtils;
 
 public class Pds2SolrDataTypeMap
 {
+    private Logger LOG;
     private Map<String, String> map;
     
     
     public Pds2SolrDataTypeMap()
     {
+        LOG = LogManager.getLogger(getClass());
         map = new HashMap<>();
     }
 
@@ -25,7 +30,7 @@ public class Pds2SolrDataTypeMap
         if(solrType != null) return solrType;
         
         solrType = guessType(pdsType);
-        System.out.println("WARNING: No PDS to Solr data type mapping for '" 
+        LOG.warn("No PDS to Solr data type mapping for '" 
                 + pdsType + "'. Will use '" + solrType + "'");
 
         map.put(pdsType, solrType);
@@ -49,7 +54,7 @@ public class Pds2SolrDataTypeMap
     
     public void load(File file) throws Exception
     {
-        System.out.println("INFO: Loading data type configuration from " + file.getAbsolutePath());
+        LOG.info("Loading data type configuration from " + file.getAbsolutePath());
         
         BufferedReader rd = null;
         

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
@@ -1,10 +1,19 @@
 package gov.nasa.pds.registry.mgr.util;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient.RemoteSolrException;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+
 
 public class SolrUtils
 {
@@ -25,5 +34,37 @@ public class SolrUtils
         }
 
         return client;
+    }
+    
+    
+    public static Set<String> getFieldNames(SolrClient client, String collectionName) throws Exception
+    {
+        try
+        {
+            SchemaRequest.Fields req = new SchemaRequest.Fields();
+            SchemaResponse.FieldsResponse resp = req.process(client, collectionName);
+    
+            List<Map<String, Object>> fields = resp.getFields();
+            Set<String> names = new TreeSet<>();
+            
+            for(Map<String, Object> field: fields)
+            {
+                String fieldName = (String)field.get("name");
+                names.add(fieldName);
+            }
+            
+            return names;
+        }
+        catch(RemoteSolrException ex)
+        {
+            int code = ex.code();
+            switch(code)
+            {
+            case 401: throw new Exception("Not authenticated.");
+            case 404: throw new Exception("Collection '" + collectionName + "' not found.");
+            }
+            
+            throw ex;
+        }
     }
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
@@ -125,7 +125,7 @@ public class SolrUtils
                 }
             }
             
-            throw new Exception(ex);
+            throw ex;
         }
     }
     

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
@@ -13,9 +13,11 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.ZkClientClusterStateProvider;
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient.RemoteExecutionException;
 import org.apache.solr.client.solrj.impl.BaseHttpSolrClient.RemoteSolrException;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.SchemaResponse;
+import org.apache.solr.common.util.NamedList;
 
 
 public class SolrUtils
@@ -45,33 +47,40 @@ public class SolrUtils
     
     public static Set<String> getFieldNames(SolrClient client, String collectionName) throws Exception
     {
+        Set<String> names = new TreeSet<>();
+
         try
         {
             SchemaRequest.Fields req = new SchemaRequest.Fields();
             SchemaResponse.FieldsResponse resp = req.process(client, collectionName);
     
             List<Map<String, Object>> fields = resp.getFields();
-            Set<String> names = new TreeSet<>();
             
             for(Map<String, Object> field: fields)
             {
                 String fieldName = (String)field.get("name");
                 names.add(fieldName);
             }
-            
-            return names;
         }
         catch(RemoteSolrException ex)
         {
-            int code = ex.code();
-            switch(code)
-            {
-            case 401: throw new Exception("Not authenticated.");
-            case 404: throw new Exception("Collection '" + collectionName + "' not found.");
-            }
-            
-            throw ex;
+            handleRemoteSolrException(ex, collectionName);
         }
+        
+        return names;
+    }
+    
+    
+    private static void handleRemoteSolrException(RemoteSolrException ex, String collectionName) throws Exception
+    {
+        int code = ex.code();
+        switch(code)
+        {
+        case 401: throw new Exception("Not authenticated.");
+        case 404: throw new Exception("Collection '" + collectionName + "' not found.");
+        }
+        
+        throw ex;
     }
     
     
@@ -88,4 +97,59 @@ public class SolrUtils
         return req;
     }
 
+    
+    public static void multiUpdate(SolrClient client, String collectionName, 
+            List<SchemaRequest.Update> updateRequests) throws Exception
+    {
+        try
+        {
+            SchemaRequest.MultiUpdate req = new SchemaRequest.MultiUpdate(updateRequests);
+            SchemaResponse.UpdateResponse resp = req.process(client, collectionName);
+        }
+        catch(RemoteExecutionException ex)
+        {
+            String msg = extractErrorMessage(ex);
+            if(msg != null)
+            {
+                throw new Exception(msg);
+            }
+
+            NamedList meta = ex.getMetaData();
+            if(meta != null)
+            {
+                msg = meta.jsonStr();
+                if(msg != null)
+                {
+                    Logger LOG = LogManager.getLogger(SolrUtils.class);
+                    LOG.error(msg);
+                }
+            }
+            
+            throw new Exception(ex);
+        }
+    }
+    
+    
+    @SuppressWarnings("rawtypes")
+    private static String extractErrorMessage(RemoteExecutionException ex)
+    {
+        // It looks ugly, but I could not find another way.
+        NamedList meta = ex.getMetaData();
+        if(meta == null) return null;
+        
+        Object obj = meta.get("error");
+        if(obj == null || !(obj instanceof NamedList)) return null;
+        
+        obj = ((NamedList)obj).get("details");
+        if(obj == null || !(obj instanceof List) || ((List)obj).isEmpty()) return null;
+
+        obj = ((List)obj).get(0);
+        if(obj == null || !(obj instanceof Map) || ((Map)obj).isEmpty()) return null;
+        
+        obj = ((Map)obj).get("errorMessages");
+        if(obj == null || !(obj instanceof List) || ((List)obj).isEmpty()) return null;
+        
+        obj = ((List)obj).get(0);
+        return obj == null ? null : obj.toString();
+    }
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/SolrUtils.java
@@ -3,9 +3,12 @@ package gov.nasa.pds.registry.mgr.util;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
@@ -19,6 +22,7 @@ public class SolrUtils
 {
     public static SolrClient createSolrClient(CommandLine cmdLine)
     {
+        Logger LOG = LogManager.getLogger(SolrUtils.class);
         SolrClient client = null;
         
         String zkHost = cmdLine.getOptionValue("zkHost");
@@ -26,11 +30,13 @@ public class SolrUtils
         {
             String solrUrl = cmdLine.getOptionValue("solrUrl", "http://localhost:8983/solr");
             client = new HttpSolrClient.Builder(solrUrl).build();
+            LOG.info("Solr URL: " + solrUrl);
         }
         else
         {
             ZkClientClusterStateProvider zk = new ZkClientClusterStateProvider(zkHost);
-            client = new CloudSolrClient.Builder(zk).build();        
+            client = new CloudSolrClient.Builder(zk).build();
+            LOG.info("Solr Zookeeper: " + zkHost);
         }
 
         return client;
@@ -67,4 +73,19 @@ public class SolrUtils
             throw ex;
         }
     }
+    
+    
+    public static SchemaRequest.AddField createAddFieldRequest(String fieldName, String fieldType)
+    {
+        Map<String, Object> params = new TreeMap<>();
+        params.put("name", fieldName);
+        params.put("type", fieldType);
+        params.put("stored", true);
+        params.put("indexed", true);
+        params.put("multiValued", true);
+        
+        SchemaRequest.AddField req = new SchemaRequest.AddField(params);
+        return req;
+    }
+
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/log/Log4jConfigurator.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/log/Log4jConfigurator.java
@@ -1,0 +1,90 @@
+package gov.nasa.pds.registry.mgr.util.log;
+
+import java.io.File;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+
+
+public class Log4jConfigurator
+{
+    public static void configure(String verbosity, String filePath) 
+    {
+        ConfigurationBuilder<BuiltConfiguration> cfg = ConfigurationBuilderFactory.newConfigurationBuilder();
+        cfg.setStatusLevel(Level.ERROR);
+        cfg.setConfigurationName("Harvest");
+        
+        // Appenders
+        addConsoleAppender(cfg, "console");
+        addFileAppender(cfg, "file", filePath);
+
+        // Root logger
+        RootLoggerComponentBuilder rootLog = cfg.newRootLogger(Level.OFF);
+        rootLog.add(cfg.newAppenderRef("console"));
+        rootLog.add(cfg.newAppenderRef("file"));
+        cfg.add(rootLog);
+        
+        // Default Harvest logger
+        Level level = parseLogLevel(verbosity);
+        LoggerComponentBuilder defLog = cfg.newLogger("gov.nasa.pds.registry", level);
+        cfg.add(defLog);
+        
+        // Minimal logger
+        LoggerComponentBuilder minLog = cfg.newLogger("registry-min-info", Level.INFO);
+        cfg.add(minLog);
+        
+        // Init Log4j
+        Configurator.initialize(cfg.build());
+    }
+    
+    
+    private static void addConsoleAppender(ConfigurationBuilder<BuiltConfiguration> cfg, String name)
+    {
+        AppenderComponentBuilder appender = cfg.newAppender(name, "CONSOLE");
+        appender.addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "[%level] %msg%n%throwable"));
+        cfg.add(appender);
+    }
+    
+    
+    private static void addFileAppender(ConfigurationBuilder<BuiltConfiguration> cfg, String name, String filePath)
+    {
+        // Use default log name if not provided
+        if(filePath == null)
+        {
+            File dir = new File("/tmp/registry");
+            dir.mkdirs();
+            filePath = "/tmp/registry/registry.log";
+        }
+        
+        AppenderComponentBuilder appender = cfg.newAppender(name, "FILE");
+        appender.addAttribute("fileName", filePath);
+        appender.addAttribute("append", false);
+        appender.add(cfg.newLayout("PatternLayout").addAttribute("pattern", "%d [%level] %msg%n%throwable"));
+        cfg.add(appender);
+    }
+    
+    
+    private static Level parseLogLevel(String verbosity)
+    {
+        switch(verbosity)
+        {
+        case "0": return Level.ALL;
+        case "1": return Level.INFO;
+        case "2": return Level.WARN;
+        case "3": return Level.ERROR;
+        }
+
+        // Logger is not setup yet. Print to console.
+        System.out.println("[WARNING] Invalid log verbosity '" + verbosity + "'. Will use 1 (Info).");
+        return Level.INFO;
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/log/RegistryLogManager.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/log/RegistryLogManager.java
@@ -1,0 +1,12 @@
+package gov.nasa.pds.registry.mgr.util.log;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RegistryLogManager
+{
+    public static Logger getMinInfoLogger()
+    {
+        return LogManager.getLogger("registry-min-info");
+    }
+}

--- a/src/main/resources/schema-gen/conf/Observing_System_Component.cfg
+++ b/src/main/resources/schema-gen/conf/Observing_System_Component.cfg
@@ -1,0 +1,2 @@
+instrument_name=string
+spacecraft_name=string

--- a/src/main/resources/schema-gen/conf/example.xml
+++ b/src/main/resources/schema-gen/conf/example.xml
@@ -6,22 +6,19 @@
     <file>PDS4_PDS_JSON_1D00.JSON</file>
   </dataDictionary>
 
-<!--
   <dataTypes baseDir="/tmp/schema">
     <file>data-types.cfg</file>
   </dataTypes>
--->
 
-<!--
   <classFilters>
-    <include>pds.Bundle</include>
+    <include>pds.Collection</include>
+    <include>pds.Primary_Result_Summary</include>
+    <include>pds.Science_Facets</include>
+    <include>pds.Observing_System_Component</include>
   </classFilters>
--->
 
-<!--
   <customGenerators baseDir="/tmp/schema">
-    <class name="pds.Internal_Reference" file="pds.internal_reference.xml" />
+    <class name="pds.Observing_System_Component" file="Observing_System_Component.cfg" />
   </customGenerators>
--->
 
 </schemaGen>

--- a/src/main/resources/schema-gen/conf/pds.internal_reference.xml
+++ b/src/main/resources/schema-gen/conf/pds.internal_reference.xml
@@ -1,7 +1,0 @@
-
-<!-- References -->
-<field name="ref_document_lid" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-<field name="ref_instrument_lid" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-<field name="ref_instrument_host_lid" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-<field name="ref_investigation_lid" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-<field name="ref_target_lid" type="string" indexed="true" stored="true" required="false" multiValued="true" />

--- a/src/main/resources/solr/collections/registry/managed-schema
+++ b/src/main/resources/solr/collections/registry/managed-schema
@@ -7,30 +7,28 @@
     <field name="vid" type="pfloat" indexed="true" stored="true" required="true" multiValued="false" />
     <field name="lidvid" type="string" indexed="true" stored="true" required="true" multiValued="false" />
     <uniqueKey>lidvid</uniqueKey>
-    <field name="product_class" type="string" indexed="true" stored="true" required="false" multiValued="false" />
-
-    <!-- Registry File Info -->
-    <field name="_file_name" type="string" indexed="true" stored="true" required="true" multiValued="false" />
-    <field name="_file_type" type="string" indexed="true" stored="true" required="true" multiValued="false" />
-    <field name="_file_size" type="plong"  indexed="true" stored="true" required="true" multiValued="false" />
-    <field name="_file_ref"  type="string" indexed="true" stored="true" required="false" multiValued="false" />
-    <field name="_file_md5"  type="string" indexed="true" stored="true" required="false" multiValued="false" />
-    <field name="_file_blob" type="binary" indexed="false" stored="true" required="false" multiValued="false" />
-
-    <field name="xml_root_element" type="string" indexed="true" stored="true" required="false" multiValued="false" />
 
     <!-- Package / transaction ID -->
     <field name="_package_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
 
     <!-- Metadata -->
     <field name="title" type="text_general" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="product_class" type="string" indexed="true" stored="true" required="false" multiValued="false" />
 
     <!-- References -->
-    <field name="document_ref" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-    <field name="instrument_ref" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-    <field name="instrument_host_ref" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-    <field name="investigation_ref" type="string" indexed="true" stored="true" required="false" multiValued="true" />
-    <field name="target_ref" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="ref_lid_document" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="ref_lid_instrument" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="ref_lid_instrument_host" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="ref_lid_investigation" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+    <field name="ref_lid_target" type="string" indexed="true" stored="true" required="false" multiValued="true" />
+
+    <!-- File Info -->
+    <field name="_file_name" type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="_file_type" type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="_file_size" type="plong"  indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="_file_ref"  type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="_file_md5"  type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="_file_blob" type="binary" indexed="false" stored="true" required="false" multiValued="false" />
 
     <!-- Timestamp, etc. -->
     <field name="timestamp" type="pdate" indexed="true" stored="true" default="NOW" multiValued="false"/>

--- a/src/main/resources/solr/collections/registry/managed-schema
+++ b/src/main/resources/solr/collections/registry/managed-schema
@@ -39,6 +39,7 @@
     <fieldType name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- Types -->
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
     <fieldType name="pint" class="solr.IntPointField" docValues="true"/>
     <fieldType name="pfloat" class="solr.FloatPointField" docValues="true"/>


### PR DESCRIPTION
Implementation of #46: 
- Use Solr schema API to dynamically update Solr collection from JSON data dictionary.
- An option to save generated Solr fields into a file (in Solr schema XML format) without updating Solr.
- Multiple data dictionaries.
- Optional class filter (either include or exclude class list).
- Custom generators (a list of field name - field type pairs) per data dictionary class.

