### PR TITLE
Multi-Node Deployment capability #8, Deploy in Test vs Prod #15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,19 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>8.5.1</version>
+            <version>8.5.2</version>
         </dependency>
         <!-- SolrJ needs it -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.24</version>
+        </dependency>
+        <!-- XML escaping, String utils -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
         <!-- File type detection -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </licenses>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -14,6 +14,7 @@ import gov.nasa.pds.registry.mgr.cmd.CliCommand;
 import gov.nasa.pds.registry.mgr.cmd.CreateRegistryCmd;
 import gov.nasa.pds.registry.mgr.cmd.DeleteDataCmd;
 import gov.nasa.pds.registry.mgr.cmd.DeleteRegistryCmd;
+import gov.nasa.pds.registry.mgr.cmd.ExportDataCmd;
 import gov.nasa.pds.registry.mgr.cmd.ExportFileCmd;
 import gov.nasa.pds.registry.mgr.cmd.GenerateSolrSchemaCmd;
 import gov.nasa.pds.registry.mgr.cmd.LoadDataCmd;
@@ -50,6 +51,7 @@ public class RegistryManagerCli
         System.out.println("  delete-registry       Delete registry collection and all its data");
         System.out.println("  load-data             Load data into registry collection");
         System.out.println("  delete-data           Delete data from registry collection");
+        System.out.println("  export-data           Export data from registry collection");
         System.out.println("  export-file           Export a file from blob storage");
         System.out.println("  set-archive-status    Set product archive status");        
         
@@ -160,13 +162,18 @@ public class RegistryManagerCli
     private void initCommands()
     {
         commands = new HashMap<>();
-        commands.put("load-data", new LoadDataCmd());
-        commands.put("delete-data", new DeleteDataCmd());
-        commands.put("export-file", new ExportFileCmd());
+
+        // Registry collection create / delete / edit
         commands.put("create-registry", new CreateRegistryCmd());
         commands.put("delete-registry", new DeleteRegistryCmd());
         commands.put("generate-solr-schema", new GenerateSolrSchemaCmd());
         commands.put("update-solr-schema", new UpdateSolrSchemaCmd());
+
+        // Data load / delete / edit
+        commands.put("load-data", new LoadDataCmd());
+        commands.put("delete-data", new DeleteDataCmd());
+        commands.put("export-data", new ExportDataCmd());
+        commands.put("export-file", new ExportFileCmd());
         commands.put("set-archive-status", new SetArchiveStatusCmd());        
     }
     
@@ -186,7 +193,7 @@ public class RegistryManagerCli
         bld = Option.builder("solrUrl").hasArg().argName("url");
         options.addOption(bld.build());
 
-        bld = Option.builder("filePath").hasArg().argName("path");
+        bld = Option.builder("file").hasArg().argName("path");
         options.addOption(bld.build());
 
         bld = Option.builder("configDir").hasArg().argName("dir");

--- a/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/RegistryManagerCli.java
@@ -222,6 +222,9 @@ public class RegistryManagerCli
         bld = Option.builder("shards").hasArg().argName("#");
         options.addOption(bld.build());
 
+        bld = Option.builder("shardsPerNode").hasArg().argName("#");
+        options.addOption(bld.build());
+
         bld = Option.builder("replicas").hasArg().argName("#");
         options.addOption(bld.build());
         

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
@@ -146,7 +146,8 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println("                           Default value is $REGISTRY_MANAGER_HOME/solr/collections/registry");
         System.out.println("  -collection <name>       Solr collection name. Default value is 'registry'");
         System.out.println("  -shards <number>         Number of shards for registry collection. Default value is 1");
-        System.out.println("  -shardsPerNode <number>  Maximum number of shards per node. Default value is the same as number of shards");
+        System.out.println("  -shardsPerNode <number>  Maximum number of shards per node for registry collection.");
+        System.out.println("                           Default value is the same as number of shards");
         System.out.println("  -replicas <number>       Number of replicas for registry collection. Default value is 1");
         System.out.println();
     }

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/CreateRegistryCmd.java
@@ -33,6 +33,7 @@ public class CreateRegistryCmd implements CliCommand
         
         String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
         int shards = parseShards(cmdLine.getOptionValue("shards", "1"));
+        int shardsPerNode = parseShards(cmdLine.getOptionValue("shardsPerNode", String.valueOf(shards)));
         int replicas = parseReplicas(cmdLine.getOptionValue("replicas", "1"));
         
         System.out.println("Creating registry collection");
@@ -41,6 +42,7 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println("Configuration directory: " + configDir.getAbsolutePath());
         System.out.println("Collection: " + collectionName);
         System.out.println("Shards: " + shards);
+        System.out.println("Shards per node: " + shardsPerNode);
         System.out.println("Replicas: " + replicas);
 
         ZkClientClusterStateProvider zk = null;
@@ -54,7 +56,8 @@ public class CreateRegistryCmd implements CliCommand
             System.out.println("Creating collection...");
             client = new CloudSolrClient.Builder(zk).build();
             CollectionAdminRequest.Create req = CollectionAdminRequest.Create
-                    .createCollection(collectionName, collectionName, 1, 1);
+                    .createCollection(collectionName, collectionName, shards, replicas);
+            req.setMaxShardsPerNode(shardsPerNode);
 
             @SuppressWarnings("unused")
             CollectionAdminResponse resp = req.process(client);
@@ -136,14 +139,15 @@ public class CreateRegistryCmd implements CliCommand
         System.out.println("Create registry collection");
         System.out.println();
         System.out.println("Optional parameters:");
-        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
-        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
-        System.out.println("                      Default value is localhost:9983");
-        System.out.println("  -configDir <dir>    Configuration directory with registry collection configuration files"); 
-        System.out.println("                      Default value is $REGISTRY_MANAGER_HOME/solr/collections/registry");
-        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
-        System.out.println("  -shards <number>    Number of shards for registry collection. Default value is 1");
-        System.out.println("  -replicas <number>  Number of replicas for registry collection. Default value is 1");
+        System.out.println("  -zkHost <host>           ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                           For example, zk1:2181,zk2:2181,zk3:2181/solr"); 
+        System.out.println("                           Default value is localhost:9983");
+        System.out.println("  -configDir <dir>         Configuration directory with registry collection configuration files"); 
+        System.out.println("                           Default value is $REGISTRY_MANAGER_HOME/solr/collections/registry");
+        System.out.println("  -collection <name>       Solr collection name. Default value is 'registry'");
+        System.out.println("  -shards <number>         Number of shards for registry collection. Default value is 1");
+        System.out.println("  -shardsPerNode <number>  Maximum number of shards per node. Default value is the same as number of shards");
+        System.out.println("  -replicas <number>       Number of replicas for registry collection. Default value is 1");
         System.out.println();
     }
 

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportDataCmd.java
@@ -1,0 +1,132 @@
+package gov.nasa.pds.registry.mgr.cmd;
+
+import java.io.File;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrQuery.SortClause;
+import org.apache.solr.common.SolrDocumentList;
+
+import gov.nasa.pds.registry.mgr.Constants;
+import gov.nasa.pds.registry.mgr.util.CloseUtils;
+import gov.nasa.pds.registry.mgr.util.solr.SolrCursor;
+import gov.nasa.pds.registry.mgr.util.solr.SolrDocWriter;
+import gov.nasa.pds.registry.mgr.util.solr.SolrUtils;
+
+
+public class ExportDataCmd implements CliCommand
+{
+    private static final int BATCH_SIZE = 100;
+
+    
+    public ExportDataCmd()
+    {
+    }
+
+    
+    @Override
+    public void run(CommandLine cmdLine) throws Exception
+    {
+        if(cmdLine.hasOption("help"))
+        {
+            printHelp();
+            return;
+        }
+
+        String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
+        
+        // File path
+        String filePath = cmdLine.getOptionValue("file");
+        if(filePath == null) 
+        {
+            System.out.println("ERROR: Missing required parameter '-file'");
+            System.out.println();
+            printHelp();
+            return;
+        }
+
+        // Query
+        String query = buildSolrQuery(cmdLine);
+        if(query == null)
+        {
+            System.out.println("ERROR: One of the following options is required: -lidvid, -packageId");
+            System.out.println();
+            printHelp();
+            return;
+        }
+        
+        SolrDocWriter writer = new SolrDocWriter(new File(filePath));
+        SolrClient client = SolrUtils.createSolrClient(cmdLine);
+        
+        try
+        {
+            SolrQuery solrQuery = new SolrQuery(query);
+
+            // Sort is required by Solr cursor
+            solrQuery.setSort(SortClause.asc("lidvid"));
+            solrQuery.setRows(BATCH_SIZE);
+
+            int numDocs = 0;
+            
+            SolrCursor cursor = new SolrCursor(client, collectionName, solrQuery);
+            while(cursor.next())
+            {
+                SolrDocumentList docs = cursor.getResults();
+                writer.write(docs);
+                
+                numDocs += docs.size();
+                if(docs.size() != 0)
+                {
+                    System.out.println("Exported " + numDocs + " document(s)");
+                }
+            }
+            
+            System.out.println("Done");
+        }
+        finally
+        {
+            CloseUtils.close(client);
+            CloseUtils.close(writer);
+        }
+    }
+
+    
+    private String buildSolrQuery(CommandLine cmdLine)
+    {
+        String id = cmdLine.getOptionValue("lidvid");
+        if(id != null)
+        {
+            return "lidvid:\"" + id + "\"";
+        }
+        
+        id = cmdLine.getOptionValue("packageId");
+        if(id != null)
+        {
+            return "_package_id:\"" + id + "\"";
+        }
+
+        return null;
+    }
+    
+    
+    public void printHelp()
+    {
+        System.out.println("Usage: registry-manager export-data <options>");
+
+        System.out.println();
+        System.out.println("Export data from registry collection");
+        System.out.println();
+        System.out.println("Required parameters:");
+        System.out.println("  -file <path>        Output file path");        
+        System.out.println("  -lidvid <id>        Export data by lidvid");
+        System.out.println("  -packageId <id>     Export data by package id"); 
+        System.out.println("Optional parameters:");
+        System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
+        System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");
+        System.out.println("                      For example, zk1:2181,zk2:2181,zk3:2181/solr");
+        System.out.println("  -collection <name>  Solr collection name. Default value is 'registry'");
+        System.out.println();
+    }
+
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportDataCmd.java
@@ -106,6 +106,11 @@ public class ExportDataCmd implements CliCommand
             return "_package_id:\"" + id + "\"";
         }
 
+        if(cmdLine.hasOption("all"))
+        {
+            return "*:*";
+        }
+
         return null;
     }
     
@@ -120,7 +125,8 @@ public class ExportDataCmd implements CliCommand
         System.out.println("Required parameters:");
         System.out.println("  -file <path>        Output file path");        
         System.out.println("  -lidvid <id>        Export data by lidvid");
-        System.out.println("  -packageId <id>     Export data by package id"); 
+        System.out.println("  -packageId <id>     Export data by package id");
+        System.out.println("  -all                Export all data");
         System.out.println("Optional parameters:");
         System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
         System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportFileCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/ExportFileCmd.java
@@ -41,10 +41,10 @@ public class ExportFileCmd implements CliCommand
         }
         
         // File path
-        String filePath = cmdLine.getOptionValue("filePath");
+        String filePath = cmdLine.getOptionValue("file");
         if(filePath == null) 
         {
-            System.out.println("ERROR: Missing required parameter '-filePath'");
+            System.out.println("ERROR: Missing required parameter '-file'");
             System.out.println();
             printHelp();
             return;
@@ -97,8 +97,8 @@ public class ExportFileCmd implements CliCommand
         System.out.println("Export a file from blob storage");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -lidvid <id>        Lidvid of a file to export from blob storage.");
-        System.out.println("  -filePath <path>    A path to a file to write."); 
+        System.out.println("  -lidvid <id>        Lidvid of a file to export from blob storage");
+        System.out.println("  -file <path>        Output file path");
         System.out.println("Optional parameters:");
         System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
         System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");

--- a/src/main/java/gov/nasa/pds/registry/mgr/cmd/LoadDataCmd.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/cmd/LoadDataCmd.java
@@ -40,10 +40,10 @@ public class LoadDataCmd implements CliCommand
         String collectionName = cmdLine.getOptionValue("collection", Constants.DEFAULT_REGISTRY_COLLECTION);
 
         // Get list of files to load
-        String filePath = cmdLine.getOptionValue("filePath");
+        String filePath = cmdLine.getOptionValue("file");
         if(filePath == null) 
         {
-            System.out.println("ERROR: Missing required parameter '-filePath'");
+            System.out.println("ERROR: Missing required parameter '-file'");
             System.out.println();
             printHelp();
             return;
@@ -154,7 +154,7 @@ public class LoadDataCmd implements CliCommand
         System.out.println("Load data into registry collection");
         System.out.println();
         System.out.println("Required parameters:");
-        System.out.println("  -filePath <path>    An XML file or a directory to load."); 
+        System.out.println("  -file <path>        An XML file or a directory to load."); 
         System.out.println("Optional parameters:");
         System.out.println("  -solrUrl <url>      Solr URL. Default is http://localhost:8983/solr");
         System.out.println("  -zkHost <host>      ZooKeeper connection string, <host:port>[,<host:port>][/path]");

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrDocWriter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrDocWriter.java
@@ -5,7 +5,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Date;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 
@@ -45,8 +49,43 @@ public class SolrDocWriter implements Closeable
     {
         writer.append("<doc>\n");
         
-        
+        for(String fieldName: doc.getFieldNames())
+        {
+            Collection<Object> values = doc.getFieldValues(fieldName);
+            if(values != null && values.size() > 0)
+            {
+                for(Object value: values)
+                {
+                    writeField(fieldName, value);
+                }
+            }
+        }
         
         writer.append("</doc>\n");
     }
+
+
+    private void writeField(String key, Object value) throws Exception
+    {
+        if(key == null || value == null || "_version_".equals(key)) return;
+        
+        writer.write("  <field name=\"");
+        writer.write(key);
+        writer.write("\">");
+        
+        String strValue;
+        if(value instanceof Date)
+        {
+            strValue = DateTimeFormatter.ISO_INSTANT.format(((Date)value).toInstant());
+        }
+        else
+        {
+            strValue = value.toString();
+        }
+        
+        writer.write(StringEscapeUtils.escapeXml(strValue));
+        
+        writer.write("</field>\n");
+    }
+    
 }

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrDocWriter.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrDocWriter.java
@@ -1,0 +1,52 @@
+package gov.nasa.pds.registry.mgr.util.solr;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+
+
+public class SolrDocWriter implements Closeable
+{
+    private Writer writer;
+
+    
+    public SolrDocWriter(File file) throws Exception
+    {
+        writer = new FileWriter(file);
+        writer.append("<add>\n");
+    }
+
+    
+    @Override
+    public void close() throws IOException
+    {
+        writer.append("</add>\n");
+        writer.close();
+    }
+
+    
+    public void write(SolrDocumentList docs) throws Exception
+    {
+        if(docs == null) return;
+        
+        for(SolrDocument doc: docs)
+        {
+            write(doc);
+        }
+    }
+    
+    
+    private void write(SolrDocument doc) throws Exception
+    {
+        writer.append("<doc>\n");
+        
+        
+        
+        writer.append("</doc>\n");
+    }
+}

--- a/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrUtils.java
+++ b/src/main/java/gov/nasa/pds/registry/mgr/util/solr/SolrUtils.java
@@ -98,6 +98,7 @@ public class SolrUtils
     }
 
     
+    @SuppressWarnings("rawtypes")
     public static void multiUpdate(SolrClient client, String collectionName, 
             List<SchemaRequest.Update> updateRequests) throws Exception
     {


### PR DESCRIPTION
1) Fixed 'create-registry' command to create collections with multiple shards and replicas. Introduced new optional parameter - 'shardsPerNode'. Default value is the same as 'shards' parameter.

2) Added new command 'export-data'
