### PR TITLE
New RabbitMQ queue

### DIFF
--- a/docker/config/rabbitmq-definitions.json
+++ b/docker/config/rabbitmq-definitions.json
@@ -45,6 +45,13 @@
       "durable": true,
       "auto_delete": false,
       "arguments": {}
+    },
+    {
+      "name": "manager.commands",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
     }
   ]
 }


### PR DESCRIPTION
## 🗒️ Summary
Added new RabbitMQ queue to handle registry manager commands, such as "update-archive-status"

## ⚙️ Test Data and/or Report
Check that "manager.commands" queue  was created in RabbitMQ.

## ♻️ Related Issues
https://github.com/NASA-PDS/pds-registry-app/issues/223
https://github.com/NASA-PDS/pds-registry-app/issues/224
