### PR TITLE
Enable debuggin of scalable harvest

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -46,6 +46,12 @@ REG_LOADER_IMAGE=nasapds/registry-loader
 # Registry Crawler Service and Registry Harvest CLI.
 HARVEST_DATA_DIR=./test-data/registry-harvest-data
 
+# don't change the directory unless you are debugging one of the component
+# if you debug one of the component, make this directory the same as the host's dir
+# MUST be an absolute path
+#CONTAINER_HARVEST_DATA_DIR=/data
+CONTAINER_HARVEST_DATA_DIR=/Users/loubrieu/git/registry/docker/test-data/registry-harvest-data/
+
 # Elasticsearch URL (the host name is the Elasticsearch service name specified in the docker compose)
 ES_URL=https://elasticsearch:9200
 

--- a/docker/default-config/rabbitmq-definitions.json
+++ b/docker/default-config/rabbitmq-definitions.json
@@ -8,6 +8,11 @@
       "tags": "administrator"
     }
   ],
+  "vhosts": [
+    {
+     "name": "/"
+    }
+  ],
   "permissions": [
     {
       "user": "harvest",

--- a/docker/default-config/registry-nginx.conf
+++ b/docker/default-config/registry-nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - ES_URL=${ES_URL}
     volumes:
       - ${HARVEST_JOB_CONFIG_FILE}:/cfg/harvest-config.xml
-      - ${HARVEST_DATA_DIR}:/data
+      - ${HARVEST_DATA_DIR}:${CONTAINER_HARVEST_DATA_DIR}
       - ./default-config/es-auth.cfg:/etc/es-auth.cfg
     networks:
       - pds
@@ -131,7 +131,7 @@ services:
       - "8005:8005"
     volumes:
       - ${HARVEST_SERVER_CONFIG_FILE}:/cfg/harvest-server.cfg
-      - ${HARVEST_DATA_DIR}:/data
+      - ${HARVEST_DATA_DIR}:${CONTAINER_HARVEST_DATA_DIR}
       - ./default-config/es-auth.cfg:/etc/es-auth.cfg
     networks:
       - pds
@@ -144,7 +144,7 @@ services:
       - "8001:8001"
     volumes:
       - $CRAWLER_SERVER_CONFIG_FILE:/cfg/crawler-server.cfg
-      - ${HARVEST_DATA_DIR}:/data
+      - ${HARVEST_DATA_DIR}:${CONTAINER_HARVEST_DATA_DIR}
     networks:
       - pds
 
@@ -154,7 +154,7 @@ services:
     image: ${REGISTRY_HARVEST_CLI_IMAGE}
     volumes:
       - ${HARVEST_JOB_CONFIG_FILE}:/cfg/harvest-job-config.xml
-      - ${HARVEST_DATA_DIR}:/data
+      - ${HARVEST_DATA_DIR}:${CONTAINER_HARVEST_DATA_DIR}
       - ${HARVEST_CLIENT_CONFIG_FILE}:/cfg/harvest-client.cfg
     networks:
       - pds
@@ -169,7 +169,7 @@ services:
       - TEST_DATA_LIDVID=${TEST_DATA_LIDVID}
     volumes:
       - ${HARVEST_JOB_CONFIG_FILE}:/cfg/harvest-job-config.xml
-      - ${HARVEST_DATA_DIR}:/data
+      - ${HARVEST_DATA_DIR}:${CONTAINER_HARVEST_DATA_DIR}
       - ${HARVEST_CLIENT_CONFIG_FILE}:/cfg/harvest-client.cfg
     networks:
       - pds
@@ -181,6 +181,7 @@ services:
     ports:
       - "81:80"
     volumes:
+      - ./default-config/registry-nginx.conf:/etc/nginx/conf.d/default.conf
       - ${HARVEST_DATA_DIR}:/usr/share/nginx/html/archive
     networks:
       - pds


### PR DESCRIPTION


## 🗒️ Summary
- make an environment variable for the data path within docker containers: when we debug a component on the host, the path to the data need to be the same on the host and within the docker containers.
- add nginx component to expose the labels and data files in a web server as done in a full registry deployment.

## ⚙️ Test Data and/or Report
Can be tested by following the procedure https://github.com/NASA-PDS/registry-harvest-service/wiki/Debug-harvest-service

Or by simply launching docker compose with an integration profile and see what data is exposed on http://localhost:81/archive/

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Helped to debug NASA-PDS/registry#64


