### PR TITLE
Resolve #120

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,11 +93,18 @@ pipeline {
             steps {
                 dir("${env.WORKSPACE}/docker") {
                     sh "$compose down --remove-orphans --timeout ${shutdown_timeout} --volumes ||:"
-                    // 🔮 TODO: Include --no-color? 
-                    sh "$compose up --detach --quiet-pull --timeout ${shutdown_timeout}"
+                }
+                dir("${env.WORKSPACE}/docker/certs") {
+                    // Now re-generate some certificates:
+                    sh "./generate-certs.sh"
+                }
+                dir("${env.WORKSPACE}/docker") {
+                    // Get the latest and greatest
+                    sh "$compose pull --quiet"
+                    // Make a bunch of containers and launch 'em; 🔮 TODO: Include --no-color? 
+                    sh "$compose up --detach --timeout ${shutdown_timeout}"
                 }
             }
-
             // 🔮 TODO: Include a `post {…}` block to do post-deployment test queries?
         }
     }

--- a/docker/certs/generate-certs.sh
+++ b/docker/certs/generate-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # ----------------------------------------------------------------------------------------------------------------
 #
@@ -8,6 +8,10 @@
 # Read more information at: https://opensearch.org/docs/latest/security-plugin/configuration/generate-certificates/
 #
 # ----------------------------------------------------------------------------------------------------------------
+
+# Sometimes—and for reasons we can't yet fathom—these get generated as _directories_ from earlier
+# runs. So let's make sure they're _gone_ before we try anything:
+rm -rf node1-key.pem node1.pem root-ca-key.pem root-ca.pem root-ca.srl
 
 # Root CA
 openssl genrsa -out root-ca-key.pem 2048
@@ -20,5 +24,6 @@ openssl req -new -key node1-key.pem -subj "/C=CA/ST=CALIFORNIA/L=LA/O=ORG/OU=PDS
 openssl x509 -req -in node1.csr -CA root-ca.pem -CAkey root-ca-key.pem -CAcreateserial -sha256 -out node1.pem -days 730
 
 # Cleanup
-rm node1-key-temp.pem
-rm node1.csr
+# Note: you normally don't want your private keys world-readable, but this makes Docker happy.
+chmod a+r node1-key.pem node1.pem root-ca-key.pem root-ca.pem root-ca.srl
+rm node1-key-temp.pem node1.csr


### PR DESCRIPTION
## 🗒️ Summary

Merge this to resolve #120 which gets OpenSearch working in the CD environment. The crux of the issue was the following:

#### On the host `pds-expo`
```console
$ ls -l certs
-rw-r--r--. 1 pds4 pds 1704 Oct 12 13:09 node1-key.pem
-rw-------. 1 pds4 pds 1204 Oct 12 13:09 node1.pem
-rw-------. 1 pds4 pds 1679 Oct 12 13:09 root-ca-key.pem
-rw-------. 1 pds4 pds 1326 Oct 12 13:09 root-ca.pem
-rw-r--r--. 1 pds4 pds   41 Oct 12 13:09 root-ca.srl
```
#### But in the container `elasticsearch`
```console
$ ls -l certs
-rw-r--r--. 1 root staff 1704 Oct 12 13:09 node1-key.pem
-rw-------. 1 root staff 1204 Oct 12 13:09 node1.pem
-rw-------. 1 root staff 1679 Oct 12 13:09 root-ca-key.pem
-rw-------. 1 root staff 1326 Oct 12 13:09 root-ca.pem
-rw-r--r--. 1 root staff   41 Oct 12 13:09 root-ca.srl
```
When OpenSearch tried to open the files `node1.pem` it was read-only to `root` and not to the user that runs inside the container.

Side issues: in some cases `node1.pem`, `root-ca-key.pem`, etc. generated as _empty directories_ and not files, so this patch also works around that issue.

## ⚙️ Test Data and/or Report

See https://pds-jenkins.jpl.nasa.gov/job/Registry/208/

## ♻️ Related Issues

- #120 

## ❗️ Important

If this is merged, the branch in PDS Jenkins for Registry needs to be updated from `i120` → `main` by visiting the [job's control panel](https://pds-jenkins.jpl.nasa.gov/job/Registry/configure) and changing the "Branch Specifier" to `*/main`.