### PR TITLE
add proxy to the path and use latest docker images

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -22,7 +22,7 @@ ES_DISCOVERY_TYPE=single-node
 # --------------------------------------------------------------------
 
 # Docker image of the Registry API
-REG_API_IMAGE=nasapds/registry-api-service:1.1.11
+REG_API_IMAGE=nasapds/registry-api-service:latest
 
 # Absolute path of the application.properties file to be used for the Registry API
 REG_API_APP_PROPERTIES_FILE=./default-config/application.properties
@@ -32,7 +32,7 @@ REG_API_APP_PROPERTIES_FILE=./default-config/application.properties
 # --------------------------------------------------------------------
 
 # Docker image of the Registry Loader
-REG_LOADER_IMAGE=nasapds/registry-loader:0.3.7
+REG_LOADER_IMAGE=nasapds/registry-loader:latest
 
 # --------------------------------------------------------------------
 # Common Configuartions

--- a/docker/default-config/application.properties
+++ b/docker/default-config/application.properties
@@ -1,7 +1,8 @@
 springfox.documentation.swagger.v2.path=/api-docs
 server.contextPath=/
 server.port=8080
-server.use-forward-headers=true
+server.forward-headers-strategy=framework
+#server.use-forward-headers=true
 
 #spring.jackson.date-format=io.swagger.RFC3339DateFormat
 spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -218,8 +218,9 @@ services:
     image: ${PROXYCRYPT_IMAGE}
     environment:
       - PROXY_URL=http://registry-api:8080/
+      - PROXY_PATH=/api/search/1/
     ports:
-      - "8443:443"
+      - "443:443"
     networks:
       - pds
 


### PR DESCRIPTION
…right with it yet

We want to reproduce the behavior in production where the api is behind a path /api/search/1/...

To simplify, I expose the api on the proxycrypt on port 443 (default as in production), since it otherwise leads us to more complication on the registry-api side.

To test, one need to call:
https://localhost/api/search/1/

Which does not work right now because more work is required on registry-api side.
