### PR TITLE
Update OpenSearch to fix issue with deploying on Linux #146

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,9 @@ pipeline {
                 dir("${env.HARVEST_DATA_DIR}") {
                     sh "find . -delete"
                 }
+                dir("${env.WORKSPACE}/docker/certs") {
+                    sh "./generate-certs.sh"
+                }
                 // Other ideas: try deploying to a different port from 8080 by using `sed` to generate
                 // a custom application.properties file and/or `docker-compose.yaml` file.
             }

--- a/docker/.env
+++ b/docker/.env
@@ -11,7 +11,7 @@
 # --------------------------------------------------------------------
 
 # Docker image of Elasticsearch/OpenSearch
-ES_IMAGE=opensearchproject/opensearch:1.1.0
+ES_IMAGE=opensearchproject/opensearch:1.2.4
 
 
 # Elasticsearch discovery mode

--- a/docker/certs/generate-certs.sh
+++ b/docker/certs/generate-certs.sh
@@ -9,6 +9,11 @@
 #
 # ----------------------------------------------------------------------------------------------------------------
 
+# Clean slate: if you started the containers before generating the certificates, Docker "helpfully"
+# creates the mapped volumes on the host as directories instead of files. Here, we get rid of those
+# directories if they happen to exist.
+rm -rf node1* root-ca.pem
+
 # Root CA
 openssl genrsa -out root-ca-key.pem 2048
 openssl req -new -x509 -sha256 -key root-ca-key.pem -subj "/C=CA/ST=CALIFORNIA/L=LA/O=ORG/OU=PDS/CN=elasticsearch" -out root-ca.pem -days 730


### PR DESCRIPTION
## 🗒️ Summary

This upgrades OpenSearch to 1.2.4, adds some safety cleanup to `generate-certs.sh`, and updates the Jenkins pipeline to include certificate generation.

However, when I run `int-tests.sh`, every single test fails and I don't know why. Could @ramesh-maddegoda @tloubrieu-jpl take a look?

## ⚙️ Test Data and/or Report

Pending.

## ♻️ Related Issues

- #146 
