### PR TITLE
Support end-to-end integration tests on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022, California Institute of Technology ("Caltech").
+ * Copyright © 2022–2023, California Institute of Technology ("Caltech").
  * U.S. Government sponsorship acknowledged.
  * 
  * All rights reserved.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,11 +81,11 @@ pipeline {
                 // a custom application.properties file and/or `docker-compose.yaml` file.
             }
         }
-        stage('🩺 Test') {
-            // The repository's upstream projects have already tested everything—there's nothing that needs
-            // to be done; However, we include the stage for reporting purposes (all pipelines should have a
-            // test stage.
+        stage('🩺 Unit Test') {
             steps {
+                // The repository's upstream projects have already tested everything—there's nothing that needs
+                // to be done; However, we include the stage for reporting purposes (all pipelines should have a
+                // unit test stage.
                 echo 'No-op test step: ✓'
             }
         }
@@ -102,6 +102,21 @@ pipeline {
             }
 
             // 🔮 TODO: Include a `post {…}` block to do post-deployment test queries?
+        }
+        stage('🏃 Integration Test') {
+            steps {
+                dir("${env.WORKSPACE}/docker") {
+                    // 🔮 TODO: It'd be better if the Docker Composition could also indicate it's completed
+                    // setup. Maybe add yet another quasi-service to it that waits for all the other
+                    // services?
+                    //
+                    // For now, we wait:
+                    sleep(time: 5, unit: "MINUTES");
+
+                    // Then test:
+                    sh "$compose run --rm reg-api-integration-test"
+                }
+            }
         }
     }
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -201,7 +201,13 @@ services:
 
   # Executes Registry API integration test as a Postman collection with test data (after waiting for data to be loaded)
   reg-api-integration-test-with-wait:
-    profiles: ["int-registry-batch-loader", "int-registry-service-loader"]
+    # For deep-archive#138, @nutjob4life writes:
+    #    I'm changing this to no profiles, because I'm not sure if it's actually useful to run any
+    #    tests at this point. The two profiles `int-registry-batch-loader` and `int-registry-service-loader`
+    #    are typically run with `--detach` and so any exit codes they might have to show pass/fail
+    #    status of the tests are lost. We can always run the tests with `./int-tests.sh`.
+    # profiles: ["int-registry-batch-loader", "int-registry-service-loader"]
+    profiles: []
     image: ${POSTMAN_NEWMAN_IMAGE}
     environment:
       - REG_API_URL=${REG_API_URL}

--- a/docker/int-test.sh
+++ b/docker/int-test.sh
@@ -41,4 +41,4 @@
 # -----------------------------------------------------------------------------------------------------
 
 # Execute Postman integration tests with docker compose
-docker compose run reg-api-integration-test
+docker compose run --rm reg-api-integration-test


### PR DESCRIPTION
## 🗒️ Summary

Support end-to-end integration tests on Jenkins:

- by including `reg-api-integration-test` in the `Jenkinsfile` 
- by removing all profiles from `reg-api-integration-test-with-wait` because any results of those tests are lost in the `up --detach`

Although the `Jenkinsfile` doesn't use the `int-test.sh` script, as a bonus of merging this, you'll help prevent the proliferation of stray containers in that script.


## ⚙️ Test Data and/or Report

See [this failed run](https://pds-jenkins.jpl.nasa.gov/job/Registry/332/), which _is expected_, because `reg-api-integration-test` currently does indeed fail.

## ♻️ Related Issues

- https://github.com/NASA-PDS/deep-archive/issues/138 (this is 1 of 2 pull requests)
