### PR TITLE
Produce full integration test logs in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,11 +111,10 @@ pipeline {
                     // services?
                     //
                     // For now, we wait:
-                    // sleep(time: 5, unit: "MINUTES");
+                    sleep(time: 5, unit: "MINUTES");
 
                     // Then test:
-                    // sh "$compose run --rm reg-api-integration-test"
-                    sh "../fail.sh"
+                    sh "./int-test-for-jenkins.sh"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,10 +111,11 @@ pipeline {
                     // services?
                     //
                     // For now, we wait:
-                    sleep(time: 5, unit: "MINUTES");
+                    // sleep(time: 5, unit: "MINUTES");
 
                     // Then test:
-                    sh "$compose run --rm reg-api-integration-test"
+                    // sh "$compose run --rm reg-api-integration-test"
+                    sh "../fail.sh"
                 }
             }
         }

--- a/docker/int-test-for-jenkins.sh
+++ b/docker/int-test-for-jenkins.sh
@@ -17,7 +17,8 @@ docker-compose \
     --profile int-registry-batch-loader \
     --project-name registry \
     --file ${WORKSPACE}/docker/docker-compose.yml \
-    --rm
+    run \
+    --rm \
     reg-api-integration-test
 status=$?
 

--- a/docker/int-test-for-jenkins.sh
+++ b/docker/int-test-for-jenkins.sh
@@ -14,12 +14,15 @@ for i in 5 4 3 2 1; do
 done
 
 docker-compose \
+    --ansi never \
     --profile int-registry-batch-loader \
     --project-name registry \
     --file ${WORKSPACE}/docker/docker-compose.yml \
     run \
     --rm \
-    reg-api-integration-test
+    --no-TTY \
+    reg-api-integration-test \
+    </dev/null
 status=$?
 
 echo ""

--- a/docker/int-test-for-jenkins.sh
+++ b/docker/int-test-for-jenkins.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+echo "Integration Tests for Jenkins"
+echo "============================="
+echo ""
+echo "👉 This is the standard output."
+echo "This is the standard error. 👈" 1>&2
+echo ""
+
+echo "Tests commencing in…"
+for i in 5 4 3 2 1; do
+    echo "…$i"
+    sleep 1
+done
+
+docker-compose \
+    --profile int-registry-batch-loader \
+    --project-name registry \
+    --file ${WORKSPACE}/docker/docker-compose.yml \
+    --rm
+    reg-api-integration-test
+status=$?
+
+echo ""
+echo "Tests exited with status: $status"
+echo "Thanks for running them! 👋"
+exit $status

--- a/fail.sh
+++ b/fail.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "This is the standard output 😅"
+echo "This is the standard error ⧮" 1>&2
+exit -1

--- a/fail.sh
+++ b/fail.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "This is the standard output 😅"
-echo "This is the standard error ⧮" 1>&2
-exit -1


### PR DESCRIPTION
## 🗒️ Summary

Merge this and you'll get to actually see the output of `docker compose run reg-api-integration-test` whenever Jenkins does its daily deploy and test of the Registry.

## ⚙️ Test Data and/or Report

See an actual such log at: https://pds-jenkins.jpl.nasa.gov/job/Registry/364/execution/node/49/log/

## ♻️ Related Issues

- [devops#33](https://github.com/NASA-PDS/devops/issues/33)
