### PR TITLE
Pull latest images in the Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,9 @@ pipeline {
                 dir("${env.WORKSPACE}/docker/certs") {
                     sh "./generate-certs.sh"
                 }
+                dir("${env.WORKSPACE}/docker") {
+                    sh "$compose pull"
+                }
                 // Other ideas: try deploying to a different port from 8080 by using `sed` to generate
                 // a custom application.properties file and/or `docker-compose.yaml` file.
             }


### PR DESCRIPTION
## 🗒️ Summary

Merge this to update the Jenkins pipeline to forcibly pull the latest images mentioned in the Docker Composition during the "build" phase.

👉 **Note:** after merging, the [Jenkins configuration for the Registry](https://pds-jenkins.jpl.nasa.gov/job/Registry/configure) should have its branch specifier changed from `*/pull-latest` back to `*/main`.

## ⚙️ Test Data and/or Report

Before the fix:
```console
$ hostname
pds-expo.jpl.nasa.gov
$ docker image ls | egrep 'registry-(api|loader).*latest'
nasapds/registry-loader                         latest              0c32984f641f   12 months ago   480MB
nasapds/registry-api-service                    latest              f456cc7e4de0   14 months ago   544MB
```
After the fix:
```console
$ docker image ls | egrep 'registry-(api|loader).*latest'
nasapds/registry-api-service                    latest              57771be577f0   6 days ago      526MB
nasapds/registry-loader                         latest              41b9fbee7ac1   8 weeks ago     474MB
```
Further, see the [Jenkins run log](https://pds-jenkins.jpl.nasa.gov/job/Registry/381/consolehttps://pds-jenkins.jpl.nasa.gov/job/Registry/381/console) wherein the number of failed assertion has plummeted from double-digits to single-digits.


## ♻️ Related Issues

- #175 
- [devops#34](https://github.com/NASA-PDS/devops/issues/34)