### PR TITLE
Registry api tests 277 326

### DIFF
--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -8979,6 +8979,62 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "NASA-PDS/registry-api#277 /properties endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", () => {",
+									"  pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response takes less than 100ms\", () => {",
+									"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
+									"});",
+									"",
+									"pm.test(\"Response contains sane number of properties\", () => {",
+									"    const responseJson = pm.response.json();",
+									"    pm.expect(responseJson.length).to.be.greaterThan(100);",
+									"});",
+									"",
+									"pm.test(\"Response property objects follow expected schema\", () => {",
+									"    const responseJson = pm.response.json();",
+									"    const expectedKeys = new Set([\"property\", \"type\"]);",
+									"    for (const propertyObj of responseJson) {",
+									"        const keys = new Set(Object.keys(propertyObj));",
+									"        pm.expect(Array.from(keys).every(key => expectedKeys.has(key)) && Array.from(expectedKeys).every(key => keys.has(key))).true;",
+									"    }",
+									"});",
+									"",
+									"// Some additional tests may be warranted in future based on presence of particular keys, key formats, or types."
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/kvp+json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/properties",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"properties"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -8936,6 +8936,49 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "NASA-PDS/registry-api#326 get retrievable product categories",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", () => {",
+									"  pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Returns correct values\", () => {",
+									"    const responseJson = pm.response.json();",
+									"    const values = new Set(responseJson);",
+									"    const expectedValues = new Set([\"any\",\"bundles\",\"collections\",\"documents\",\"observationals\"]);",
+									"    pm.expect(Array.from(values).every(val => expectedValues.has(val)) && Array.from(expectedValues).every(val => values.has(val))).true;",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/kvp+json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/classes",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"classes"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}


### PR DESCRIPTION
## 🗒️ Summary
Adds tests for the following PRs

https://github.com/NASA-PDS/registry-api/pull/322
https://github.com/NASA-PDS/registry-api/pull/328

## ⚙️ Test Data and/or Report
Postman tests pass
Github Branch tests fail due to (at least) lint, but that's nothing new and unrelated to this PR. 

## ♻️ Related Issues
https://github.com/NASA-PDS/registry-api/issues/277
https://github.com/NASA-PDS/registry-api/issues/326

Do not de-draft/merge until relevant registry-api PRs are merged (@jordanpadams @tloubrieu-jpl related: https://jpl.slack.com/archives/GCGR1R3A4/p1682534613061049)