### PR TITLE
Automatically registers nightly test runs in CAE TestRail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,12 @@
 /*
  * Copyright © 2022–2023, California Institute of Technology ("Caltech").
  * U.S. Government sponsorship acknowledged.
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * • Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
  * • Redistributions must reproduce the above copyright notice, this list of
@@ -16,7 +16,7 @@
  * Laboratory, nor the names of its contributors may be used to endorse or
  * promote products derived from this software without specific prior written
  * permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -78,7 +78,7 @@ pipeline {
                     sh "./generate-certs.sh"
                 }
                 dir("${env.WORKSPACE}/docker") {
-                    sh "$compose pull"
+                    sh "$compose pull --quiet"
                 }
                 // Other ideas: try deploying to a different port from 8080 by using `sed` to generate
                 // a custom application.properties file and/or `docker-compose.yaml` file.
@@ -117,7 +117,9 @@ pipeline {
                     sleep(time: 5, unit: "MINUTES");
 
                     // Then test:
-                    sh "./int-test-for-jenkins.sh"
+                    withCredentials([usernamePassword(credentialsId: 'newman-to-testrail', usernameVariable: 'TESTRAIL_USERNAME', passwordVariable: 'TESTRAIL_APIKEY')]) {
+                        sh "./int-test-for-jenkins.sh"
+                    }
                 }
             }
         }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -222,6 +222,7 @@ services:
     environment:
       TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov/testrail
       TESTRAIL_PROJECTID: 168
+      TESTRAIL_SUITEID: 12824
       TESTRAIL_TITLE: Registry API Newman tests via Jenkins
       # Empty values here inherit from the host environment, which must provide these:
       TESTRAIL_USERNAME:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -218,7 +218,7 @@ services:
   # Executes Registry API integration tests as a Postman collection and reports the results into JPL TestRail
   testrail-reporting-test:
     profiles: []
-    image: ${POSTMAN_NEWMAN_IMAGE}
+    image: nasapds/postman-with-testrail-reporter
     environment:
       TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov
       TESTRAIL_PROJECTID: 168

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -215,6 +215,23 @@ services:
       - pds
     command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL}"
 
+  # Executes Registry API integration tests as a Postman collection and reports the results into JPL TestRail
+  testrail-reporting-test:
+    profiles: []
+    image: ${POSTMAN_NEWMAN_IMAGE}
+    environment:
+      TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov
+      TESTRAIL_PROJECTID: 168
+      TESTRAIL_TITLE: Registry API Newman tests via Jenkins
+      # Empty values here inherit from the host environment, which must provide these:
+      TESTRAIL_USERNAME:
+      TESTRAIL_APIKEY:
+    volumes:
+      - ${POSTMAN_COLLECTION_FILE}:/postman/postman-collection.json
+    networks:
+      - pds
+    command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL} --reporters cli,testrail"
+
   # Executes Registry API integration test as a Postman collection with test data (after waiting for data to be loaded)
   reg-api-integration-test-with-wait:
     # For deep-archive#138, @nutjob4life writes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -218,7 +218,7 @@ services:
   # Executes Registry API integration tests as a Postman collection and reports the results into JPL TestRail
   testrail-reporting-test:
     profiles: []
-    image: nasapds/postman-with-testrail-reporter
+    image: nasapds/newman-with-testrail-reporter
     environment:
       TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov
       TESTRAIL_PROJECTID: 168

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -220,7 +220,7 @@ services:
     profiles: []
     image: nasapds/newman-with-testrail-reporter
     environment:
-      TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov
+      TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov/testrail
       TESTRAIL_PROJECTID: 168
       TESTRAIL_TITLE: Registry API Newman tests via Jenkins
       # Empty values here inherit from the host environment, which must provide these:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -217,7 +217,7 @@ services:
 
   # Executes Registry API integration tests as a Postman collection and reports the results into JPL TestRail
   testrail-reporting-test:
-    profiles: []
+    profiles: ["testrail-reporting"]
     image: nasapds/newman-with-testrail-reporter
     environment:
       TESTRAIL_DOMAIN: cae-testrail.jpl.nasa.gov/testrail

--- a/docker/int-test-for-jenkins.sh
+++ b/docker/int-test-for-jenkins.sh
@@ -21,7 +21,7 @@ docker-compose \
     run \
     --rm \
     --no-TTY \
-    reg-api-integration-test \
+    testrail-reporting-test \
     </dev/null
 status=$?
 

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -8817,23 +8817,23 @@
 					"response": []
 				},
 				{
-					"name": "C1274687 NASA-PDS/pds-api#72",
+					"name": "NASA-PDS/pds-api#72",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
+									"pm.test(\"C1274687 Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
 									"var data = pm.response.json().data;",
 									"",
-									"pm.test(\"Number of results is 1\", () => {",
+									"pm.test(\"C1274687 Number of results is 1\", () => {",
 									"    pm.expect(data.length).to.equal(1); ",
 									"});",
 									"",
-									"pm.test(\"time found in range\", () => {",
+									"pm.test(\"C1274687 time found in range\", () => {",
 									"    pm.expect(data[0].start_date_time).to.eql(\"2018-05-05T00:00:00Z\"); ",
 									"});",
 									"",

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -29,7 +29,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 406\", () => {",
+																	"pm.test(\"C1274687 Status code is 406\", () => {",
 																	"  pm.response.to.have.status(406);",
 																	"});",
 																	"",
@@ -179,11 +179,11 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Response takes less than 1s\", () => {",
+																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"Status code is 200\", () => {",
+																	"pm.test(\"C1274687 Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});"
 																],
@@ -330,26 +330,26 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 200\", () => {",
+																	"pm.test(\"C1274687 Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"Has meta\", () => {",
+																	"pm.test(\"C1274687 Has meta\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('meta');",
 																	"});",
 																	"",
-																	"pm.test(\"Meta has ops:Tracking_Meta\", () => {",
+																	"pm.test(\"C1274687 Meta has ops:Tracking_Meta\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta).to.have.property('ops:Tracking_Meta');",
 																	"});",
 																	"",
-																	"pm.test(\"Ops:Tracking_Meta has ops:archive_status\", () => {",
+																	"pm.test(\"C1274687 Ops:Tracking_Meta has ops:archive_status\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta[\"ops:Tracking_Meta\"]).to.have.property('ops:archive_status');",
 																	"});",
 																	"",
-																	"pm.test(\"Ops:archive_status value is archived\", () => {",
+																	"pm.test(\"C1274687 Ops:archive_status value is archived\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta[\"ops:Tracking_Meta\"]['ops:archive_status']).to.eql('archived');",
 																	"});",
@@ -501,15 +501,15 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Response takes less than 1s\", () => {",
+																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"Status code is 200\", () => {",
+																	"pm.test(\"C1274687 Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"Has id\", () => {",
+																	"pm.test(\"C1274687 Has id\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('id');",
 																	"});",
@@ -658,11 +658,11 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Response takes less than 1s\", () => {",
+																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"Status code is 200\", () => {",
+																	"pm.test(\"C1274687 Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	""
@@ -812,15 +812,15 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Response takes less than 1s\", () => {",
+																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"Status code is 200\", () => {",
+																	"pm.test(\"C1274687 Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"Has pds:Citation_Information.pds:description\", () => {",
+																	"pm.test(\"C1274687 Has pds:Citation_Information.pds:description\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('pds:Citation_Information.pds:description');",
 																	"});",
@@ -979,7 +979,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1117,7 +1117,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1261,7 +1261,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1399,7 +1399,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1537,7 +1537,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1681,7 +1681,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1825,7 +1825,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"Status code is 404\", () => {",
+																	"pm.test(\"C1274687 Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1965,7 +1965,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 404\", () => {",
+															"pm.test(\"C1274687 Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -2110,20 +2110,20 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Response takes less than 1s\", () => {",
+													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"Has summary\", () => {",
+													"pm.test(\"C1274687 Has summary\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('summary');",
 													"});",
 													"",
-													"pm.test(\"Has data\", () => {",
+													"pm.test(\"C1274687 Has data\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('data');",
 													"});",
@@ -2273,20 +2273,20 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Response takes less than 1s\", () => {",
+													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"Has summary\", () => {",
+													"pm.test(\"C1274687 Has summary\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('summary');",
 													"});",
 													"",
-													"pm.test(\"Has data\", () => {",
+													"pm.test(\"C1274687 Has data\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('data');",
 													"});",
@@ -2443,15 +2443,15 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Response takes less than 1s\", () => {",
+													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"Has id\", () => {",
+													"pm.test(\"C1274687 Has id\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('id');",
 													"});",
@@ -2608,7 +2608,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -2766,7 +2766,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -2928,7 +2928,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3096,7 +3096,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3268,7 +3268,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3440,7 +3440,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3615,7 +3615,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3787,7 +3787,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3960,7 +3960,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4117,7 +4117,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4288,7 +4288,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4521,20 +4521,20 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Response takes less than 1s\", () => {",
+															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"Status code is 406\", () => {",
+															"pm.test(\"C1274687 Status code is 406\", () => {",
 															"  pm.response.to.have.status(406);",
 															"});",
 															"",
-															"pm.test(\"Has message\", () => {",
+															"pm.test(\"C1274687 Has message\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('message');",
 															"});",
 															"",
-															"pm.test(\"Message value\", function () {",
+															"pm.test(\"C1274687 Message value\", function () {",
 															"  pm.expect(pm.response.json().name).to.eql(pm.environment.get(\"The Accept header value application/not-supported is not supported, supported values are application/csv, application/xml, text/html, application/json, */*, application/vnd.nasa.pds.pds4+json, text/csv, text/xml, application/kvp+json, application/vnd.nasa.pds.pds4+xml\"));",
 															"});",
 															"",
@@ -4579,11 +4579,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Response takes less than 1s\", () => {",
+															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"Status code is 200\", () => {",
+															"pm.test(\"C1274687 Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4626,11 +4626,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Response takes less than 1s\", () => {",
+															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"Status code is 200\", () => {",
+															"pm.test(\"C1274687 Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4673,11 +4673,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Response takes less than 1s\", () => {",
+															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"Status code is 200\", () => {",
+															"pm.test(\"C1274687 Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4750,7 +4750,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 404\", () => {",
+															"pm.test(\"C1274687 Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -4787,7 +4787,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 404\", () => {",
+															"pm.test(\"C1274687 Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -4866,7 +4866,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5028,7 +5028,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5190,7 +5190,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5352,7 +5352,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5519,7 +5519,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5686,7 +5686,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5843,7 +5843,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 400\", () => {",
+													"pm.test(\"C1274687 Status code is 400\", () => {",
 													"  pm.response.to.have.status(400);",
 													"});"
 												],
@@ -6001,7 +6001,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6158,7 +6158,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6315,7 +6315,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6472,7 +6472,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6629,7 +6629,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6786,7 +6786,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6948,7 +6948,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7110,7 +7110,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7272,7 +7272,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7434,7 +7434,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7596,7 +7596,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7758,7 +7758,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"Status code is 200\", () => {",
+													"pm.test(\"C1274687 Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7938,15 +7938,15 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Response takes less than 1s\", () => {",
+															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"Status code is 200\", () => {",
+															"pm.test(\"C1274687 Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});",
 															"",
-															"pm.test(\"Has id\", () => {",
+															"pm.test(\"C1274687 Has id\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('id');",
 															"});"
@@ -8090,7 +8090,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 404\", () => {",
+															"pm.test(\"C1274687 Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -8228,7 +8228,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 404\", () => {",
+															"pm.test(\"C1274687 Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -8376,16 +8376,16 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"Status code is 200\", () => {",
+															"pm.test(\"C1274687 Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});",
 															"",
-															"pm.test(\"Has summary\", () => {",
+															"pm.test(\"C1274687 Has summary\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('summary');",
 															"});",
 															"",
-															"pm.test(\"Has data\", () => {",
+															"pm.test(\"C1274687 Has data\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('data');",
 															"});",
@@ -8535,15 +8535,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Response takes less than 1s\", () => {",
+											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"Has data\", () => {",
+											"pm.test(\"C1274687 Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8593,15 +8593,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Response takes less than 1s\", () => {",
+											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"Has data\", () => {",
+											"pm.test(\"C1274687 Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8652,15 +8652,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Response takes less than 1s\", () => {",
+											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"Status code is 200\", () => {",
+											"pm.test(\"C1274687 Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"Has data\", () => {",
+											"pm.test(\"C1274687 Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8823,17 +8823,17 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
+									"pm.test(\"C1274687 Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
 									"var data = pm.response.json().data;",
 									"",
-									"pm.test(\"Number of results is 1\", () => {",
+									"pm.test(\"C1274687 Number of results is 1\", () => {",
 									"    pm.expect(data.length).to.equal(1); ",
 									"});",
 									"",
-									"pm.test(\"time found in range\", () => {",
+									"pm.test(\"C1274687 time found in range\", () => {",
 									"    pm.expect(data[0].start_date_time).to.eql(\"2018-05-05T00:00:00Z\"); ",
 									"});",
 									"",
@@ -8875,25 +8875,25 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Response takes less than 1s\", () => {",
+									"pm.test(\"C1274687 Response takes less than 1s\", () => {",
 									"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 									"});",
 									"",
-									"pm.test(\"Status code is 200\", () => {",
+									"pm.test(\"C1274687 Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Has lid\", () => {",
+									"pm.test(\"C1274687 Has lid\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.have.property('lid');",
 									"});",
 									"",
-									"pm.test(\"Has pds:Primary_Result_Summary.pds:purpose\", () => {",
+									"pm.test(\"C1274687 Has pds:Primary_Result_Summary.pds:purpose\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.have.property('pds:Primary_Result_Summary.pds:purpose');",
 									"});",
 									"",
-									"pm.test(\"Has not ref_lid_instrument\", () => {",
+									"pm.test(\"C1274687 Has not ref_lid_instrument\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.not.have.property('ref_lid_instrument');",
 									"});",
@@ -8944,11 +8944,11 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
+									"pm.test(\"C1274687 Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Returns correct values\", () => {",
+									"pm.test(\"C1274687 Returns correct values\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    const values = new Set(responseJson);",
 									"    const expectedValues = new Set([\"any\",\"bundles\",\"collections\",\"documents\",\"observationals\"]);",
@@ -8987,20 +8987,20 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"Status code is 200\", () => {",
+									"pm.test(\"C1274687 Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Response takes less than 100ms\", () => {",
+									"pm.test(\"C1274687 Response takes less than 100ms\", () => {",
 									"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 									"});",
 									"",
-									"pm.test(\"Response contains sane number of properties\", () => {",
+									"pm.test(\"C1274687 Response contains sane number of properties\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson.length).to.be.greaterThan(100);",
 									"});",
 									"",
-									"pm.test(\"Response property objects follow expected schema\", () => {",
+									"pm.test(\"C1274687 Response property objects follow expected schema\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    const expectedKeys = new Set([\"property\", \"type\"]);",
 									"    for (const propertyObj of responseJson) {",

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -29,7 +29,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 406\", () => {",
+																	"pm.test(\"Status code is 406\", () => {",
 																	"  pm.response.to.have.status(406);",
 																	"});",
 																	"",
@@ -179,11 +179,11 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+																	"pm.test(\"Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Status code is 200\", () => {",
+																	"pm.test(\"Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});"
 																],
@@ -330,26 +330,26 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 200\", () => {",
+																	"pm.test(\"Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Has meta\", () => {",
+																	"pm.test(\"Has meta\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('meta');",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Meta has ops:Tracking_Meta\", () => {",
+																	"pm.test(\"Meta has ops:Tracking_Meta\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta).to.have.property('ops:Tracking_Meta');",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Ops:Tracking_Meta has ops:archive_status\", () => {",
+																	"pm.test(\"Ops:Tracking_Meta has ops:archive_status\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta[\"ops:Tracking_Meta\"]).to.have.property('ops:archive_status');",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Ops:archive_status value is archived\", () => {",
+																	"pm.test(\"Ops:archive_status value is archived\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson.meta[\"ops:Tracking_Meta\"]['ops:archive_status']).to.eql('archived');",
 																	"});",
@@ -501,15 +501,15 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+																	"pm.test(\"Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Status code is 200\", () => {",
+																	"pm.test(\"Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Has id\", () => {",
+																	"pm.test(\"Has id\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('id');",
 																	"});",
@@ -658,11 +658,11 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+																	"pm.test(\"Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Status code is 200\", () => {",
+																	"pm.test(\"Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	""
@@ -812,15 +812,15 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+																	"pm.test(\"Response takes less than 1s\", () => {",
 																	"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Status code is 200\", () => {",
+																	"pm.test(\"Status code is 200\", () => {",
 																	"  pm.response.to.have.status(200);",
 																	"});",
 																	"",
-																	"pm.test(\"C1274687 Has pds:Citation_Information.pds:description\", () => {",
+																	"pm.test(\"Has pds:Citation_Information.pds:description\", () => {",
 																	"    const responseJson = pm.response.json();",
 																	"    pm.expect(responseJson).to.have.property('pds:Citation_Information.pds:description');",
 																	"});",
@@ -979,7 +979,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1117,7 +1117,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1261,7 +1261,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1399,7 +1399,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1537,7 +1537,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1681,7 +1681,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1825,7 +1825,7 @@
 															"listen": "test",
 															"script": {
 																"exec": [
-																	"pm.test(\"C1274687 Status code is 404\", () => {",
+																	"pm.test(\"Status code is 404\", () => {",
 																	"  pm.response.to.have.status(404);",
 																	"});"
 																],
@@ -1965,7 +1965,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 404\", () => {",
+															"pm.test(\"Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -2110,20 +2110,20 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+													"pm.test(\"Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"C1274687 Has summary\", () => {",
+													"pm.test(\"Has summary\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('summary');",
 													"});",
 													"",
-													"pm.test(\"C1274687 Has data\", () => {",
+													"pm.test(\"Has data\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('data');",
 													"});",
@@ -2273,20 +2273,20 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+													"pm.test(\"Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"C1274687 Has summary\", () => {",
+													"pm.test(\"Has summary\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('summary');",
 													"});",
 													"",
-													"pm.test(\"C1274687 Has data\", () => {",
+													"pm.test(\"Has data\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('data');",
 													"});",
@@ -2443,15 +2443,15 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+													"pm.test(\"Response takes less than 1s\", () => {",
 													"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 													"});",
 													"",
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});",
 													"",
-													"pm.test(\"C1274687 Has id\", () => {",
+													"pm.test(\"Has id\", () => {",
 													"    const responseJson = pm.response.json();",
 													"    pm.expect(responseJson).to.have.property('id');",
 													"});",
@@ -2608,7 +2608,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -2766,7 +2766,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -2928,7 +2928,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3096,7 +3096,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3268,7 +3268,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3440,7 +3440,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3615,7 +3615,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3787,7 +3787,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -3960,7 +3960,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4117,7 +4117,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4288,7 +4288,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});"
 										],
@@ -4521,20 +4521,20 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+															"pm.test(\"Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"C1274687 Status code is 406\", () => {",
+															"pm.test(\"Status code is 406\", () => {",
 															"  pm.response.to.have.status(406);",
 															"});",
 															"",
-															"pm.test(\"C1274687 Has message\", () => {",
+															"pm.test(\"Has message\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('message');",
 															"});",
 															"",
-															"pm.test(\"C1274687 Message value\", function () {",
+															"pm.test(\"Message value\", function () {",
 															"  pm.expect(pm.response.json().name).to.eql(pm.environment.get(\"The Accept header value application/not-supported is not supported, supported values are application/csv, application/xml, text/html, application/json, */*, application/vnd.nasa.pds.pds4+json, text/csv, text/xml, application/kvp+json, application/vnd.nasa.pds.pds4+xml\"));",
 															"});",
 															"",
@@ -4579,11 +4579,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+															"pm.test(\"Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"C1274687 Status code is 200\", () => {",
+															"pm.test(\"Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4626,11 +4626,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+															"pm.test(\"Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"C1274687 Status code is 200\", () => {",
+															"pm.test(\"Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4673,11 +4673,11 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+															"pm.test(\"Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"C1274687 Status code is 200\", () => {",
+															"pm.test(\"Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});"
 														],
@@ -4750,7 +4750,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 404\", () => {",
+															"pm.test(\"Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -4787,7 +4787,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 404\", () => {",
+															"pm.test(\"Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -4866,7 +4866,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5028,7 +5028,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5190,7 +5190,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5352,7 +5352,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5519,7 +5519,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5686,7 +5686,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -5843,7 +5843,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 400\", () => {",
+													"pm.test(\"Status code is 400\", () => {",
 													"  pm.response.to.have.status(400);",
 													"});"
 												],
@@ -6001,7 +6001,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6158,7 +6158,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6315,7 +6315,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6472,7 +6472,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6629,7 +6629,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6786,7 +6786,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -6948,7 +6948,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7110,7 +7110,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7272,7 +7272,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7434,7 +7434,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7596,7 +7596,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7758,7 +7758,7 @@
 											"listen": "test",
 											"script": {
 												"exec": [
-													"pm.test(\"C1274687 Status code is 200\", () => {",
+													"pm.test(\"Status code is 200\", () => {",
 													"  pm.response.to.have.status(200);",
 													"});"
 												],
@@ -7938,15 +7938,15 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+															"pm.test(\"Response takes less than 1s\", () => {",
 															"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 															"});",
 															"",
-															"pm.test(\"C1274687 Status code is 200\", () => {",
+															"pm.test(\"Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});",
 															"",
-															"pm.test(\"C1274687 Has id\", () => {",
+															"pm.test(\"Has id\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('id');",
 															"});"
@@ -8090,7 +8090,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 404\", () => {",
+															"pm.test(\"Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -8228,7 +8228,7 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 404\", () => {",
+															"pm.test(\"Status code is 404\", () => {",
 															"  pm.response.to.have.status(404);",
 															"});"
 														],
@@ -8376,16 +8376,16 @@
 													"listen": "test",
 													"script": {
 														"exec": [
-															"pm.test(\"C1274687 Status code is 200\", () => {",
+															"pm.test(\"Status code is 200\", () => {",
 															"  pm.response.to.have.status(200);",
 															"});",
 															"",
-															"pm.test(\"C1274687 Has summary\", () => {",
+															"pm.test(\"Has summary\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('summary');",
 															"});",
 															"",
-															"pm.test(\"C1274687 Has data\", () => {",
+															"pm.test(\"Has data\", () => {",
 															"    const responseJson = pm.response.json();",
 															"    pm.expect(responseJson).to.have.property('data');",
 															"});",
@@ -8535,15 +8535,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+											"pm.test(\"Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"C1274687 Has data\", () => {",
+											"pm.test(\"Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8593,15 +8593,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+											"pm.test(\"Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"C1274687 Has data\", () => {",
+											"pm.test(\"Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8652,15 +8652,15 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+											"pm.test(\"Response takes less than 1s\", () => {",
 											"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 											"});",
 											"",
-											"pm.test(\"C1274687 Status code is 200\", () => {",
+											"pm.test(\"Status code is 200\", () => {",
 											"  pm.response.to.have.status(200);",
 											"});",
 											"",
-											"pm.test(\"C1274687 Has data\", () => {",
+											"pm.test(\"Has data\", () => {",
 											"    const responseJson = pm.response.json();",
 											"    pm.expect(responseJson).to.have.property('data');",
 											"})",
@@ -8817,23 +8817,23 @@
 					"response": []
 				},
 				{
-					"name": "NASA-PDS/pds-api#72",
+					"name": "C1274687 NASA-PDS/pds-api#72",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"C1274687 Status code is 200\", () => {",
+									"pm.test(\"Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
 									"var data = pm.response.json().data;",
 									"",
-									"pm.test(\"C1274687 Number of results is 1\", () => {",
+									"pm.test(\"Number of results is 1\", () => {",
 									"    pm.expect(data.length).to.equal(1); ",
 									"});",
 									"",
-									"pm.test(\"C1274687 time found in range\", () => {",
+									"pm.test(\"time found in range\", () => {",
 									"    pm.expect(data[0].start_date_time).to.eql(\"2018-05-05T00:00:00Z\"); ",
 									"});",
 									"",
@@ -8875,25 +8875,25 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"C1274687 Response takes less than 1s\", () => {",
+									"pm.test(\"Response takes less than 1s\", () => {",
 									"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 									"});",
 									"",
-									"pm.test(\"C1274687 Status code is 200\", () => {",
+									"pm.test(\"Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"C1274687 Has lid\", () => {",
+									"pm.test(\"Has lid\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.have.property('lid');",
 									"});",
 									"",
-									"pm.test(\"C1274687 Has pds:Primary_Result_Summary.pds:purpose\", () => {",
+									"pm.test(\"Has pds:Primary_Result_Summary.pds:purpose\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.have.property('pds:Primary_Result_Summary.pds:purpose');",
 									"});",
 									"",
-									"pm.test(\"C1274687 Has not ref_lid_instrument\", () => {",
+									"pm.test(\"Has not ref_lid_instrument\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson).to.not.have.property('ref_lid_instrument');",
 									"});",
@@ -8944,11 +8944,11 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"C1274687 Status code is 200\", () => {",
+									"pm.test(\"Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"C1274687 Returns correct values\", () => {",
+									"pm.test(\"Returns correct values\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    const values = new Set(responseJson);",
 									"    const expectedValues = new Set([\"any\",\"bundles\",\"collections\",\"documents\",\"observationals\"]);",
@@ -8987,20 +8987,20 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"pm.test(\"C1274687 Status code is 200\", () => {",
+									"pm.test(\"Status code is 200\", () => {",
 									"  pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"C1274687 Response takes less than 100ms\", () => {",
+									"pm.test(\"Response takes less than 100ms\", () => {",
 									"    pm.expect(pm.response.responseTime).to.be.below(1000); ",
 									"});",
 									"",
-									"pm.test(\"C1274687 Response contains sane number of properties\", () => {",
+									"pm.test(\"Response contains sane number of properties\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    pm.expect(responseJson.length).to.be.greaterThan(100);",
 									"});",
 									"",
-									"pm.test(\"C1274687 Response property objects follow expected schema\", () => {",
+									"pm.test(\"Response property objects follow expected schema\", () => {",
 									"    const responseJson = pm.response.json();",
 									"    const expectedKeys = new Set([\"property\", \"type\"]);",
 									"    for (const propertyObj of responseJson) {",


### PR DESCRIPTION
## 🗒️ Summary

Merge this to resolve [devops#35](https://github.com/NASA-PDS/devops/issues/35) which'll do the following:

-   Update the Jenkins pipeline so that TestRail credentials are available
-   Instantiate a service in the Docker Composition that runs Newman tests with the TestRail Reporter, using the credentials from above
    -   In addition, it uses TestRail project ID 168 (which is PDS)
    -   And TestRail suite ID 12824 (which is "PDS Registry API, automated tests")
- Adds the test case ID `C1274687` to a single test (with three assertions) in the Postman collection (which is "As an API user, I want to search by a temporal range as an ISO-8601 time interval")


## ⚙️ Test Data and/or Report

- Jenkins: https://pds-jenkins.jpl.nasa.gov/job/Registry/454/
- TestRail: https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/view/33672&group_by=cases:section_id&group_order=asc

## ♻️ Related Issues

- [devops#35](https://github.com/NASA-PDS/devops/issues/35)


## 🔮 Future Work

- The test case ID `C1274687` is recorded in the `postman_collection.json` file only, not in Postman. Suppose someone were to fire up Postman and add a new test. Exporting a fresh `postman_collection.json` file would overwrite all test case IDs. The test case IDs should be in Postman itself (i.e., each `pm.test("Summary of assertion being made", …)` → `pm.test("C1234567 Summary of assertion being made", …)`
- PDS Jenkins has secrets in order to pass along to the TestRail reporter so it can use the TestRail API to register the results of Newman tests. These credentials currently consist of a username and an API key. The username is `Sean.C.Kelly@jpl.nasa.gov`. We should have a "service" account instead, since despite my rare use of public transportation, I could still get hit by a bus.
