### PR TITLE
update tests for registry-api PR 380

### DIFF
--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -349,7 +349,7 @@
 									"});",
 									"",
 									"pm.test(\"C2488912 Collection DOI is [10.17189/1517568]\", () => {",
-									"    pm.expect(data[0][\"pds:Citation_Information.pds:doi\"]).to.equal(\"[10.17189/1517568]\"); ",
+									"    pm.expect(data[0][\"pds:Citation_Information.pds:doi\"]).to.equal(\"10.17189/1517568\"); ",
 									"});",
 									"",
 									""


### PR DESCRIPTION
## 🗒️ Summary
registry-api PR 380 changes kvp format for array-like values

## ⚙️ Test Data and/or Report
No tests to perform

## ♻️ Related Issues
related to https://github.com/NASA-PDS/registry-api/pull/380