### PR TITLE
Add legacy sync to sweeper, fix integration test

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - PROV_CREDENTIALS=${PROV_CREDENTIALS}
       - LOGLEVEL=DEBUG
       - DEV_MODE=1
+    command: ["/usr/local/bin/sweepers_driver.py", "--legacy-sync"]
     networks:
       - pds
     depends_on:

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -1,11 +1,11 @@
 {
 	"info": {
-		"_postman_id": "478f45c4-7b67-4c79-829b-18373bc14aba",
-		"name": "Planetary Data System API Reference Tests",
+		"_postman_id": "23f6b1ba-f2d6-4126-9385-1cb78121b18c",
+		"name": "Planetary Data System API Reference Tests Copy 2",
 		"description": "Federated PDS API which provides actionable end points standardized\nbetween the different nodes.\n\n\nContact Support:\n Email: pds-operator@jpl.nasa.gov",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "11337552",
-		"_collection_link": "https://interstellar-satellite-406261.postman.co/workspace/My-Workspace~2ee1fece-93c6-4f38-806d-fa321e2e92d5/collection/11337552-478f45c4-7b67-4c79-829b-18373bc14aba?action=share&source=collection_link&creator=11337552"
+		"_collection_link": "https://interstellar-satellite-406261.postman.co/workspace/My-Workspace~2ee1fece-93c6-4f38-806d-fa321e2e92d5/collection/11337552-23f6b1ba-f2d6-4126-9385-1cb78121b18c?action=share&source=collection_link&creator=11337552"
 	},
 	"item": [
 		{
@@ -708,7 +708,7 @@
 									"",
 									"pm.test(\"C2488844 Response contains same number of properties\", () => {",
 									"    const responseJson = pm.response.json();",
-									"    pm.expect(responseJson.length).to.be.eql(140);",
+									"    pm.expect(responseJson.length).to.be.eql(141);",
 									"});",
 									"",
 									"pm.test(\"C2488844 Response property objects follow expected schema\", () => {",
@@ -785,6 +785,42 @@
 							],
 							"path": [
 								"classes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "NASA-PDS/registry-api#375 csv response, use | as inner list separator",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/csv",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/products/:lidvid?fields=lid,pds:File.pds:file_size",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"products",
+								":lidvid"
+							],
+							"query": [
+								{
+									"key": "fields",
+									"value": "lid,pds:File.pds:file_size"
+								}
+							],
+							"variable": [
+								{
+									"key": "lidvid",
+									"value": "urn:nasa:pds:mars2020.spice::1.0"
+								}
 							]
 						}
 					},


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
- Add legacy synchronization option to sweeper to test this case in the deployment
- Fix a minor failure in the postman tests
