### PR TITLE
Opensearch postman

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -235,7 +235,7 @@ services:
       - ${POSTMAN_COLLECTION_FILE}:/postman/postman-collection.json
     networks:
       - pds
-    command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL} --env-var opensearchUrl=${ES_URL} --reporters cli,testrail"
+    command: "run /postman/postman-collection.json --insecure --env-var baseUrl=${REG_API_URL} --env-var opensearchUrl=${ES_URL} --reporters cli,testrail"
 
   # Executes Registry API integration test as a Postman collection with test data (after waiting for data to be loaded)
   reg-api-integration-test-with-wait:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -235,7 +235,7 @@ services:
       - ${POSTMAN_COLLECTION_FILE}:/postman/postman-collection.json
     networks:
       - pds
-    command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL} --reporters cli,testrail"
+    command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL} --env-var opensearchUrl=${ES_URL} --reporters cli,testrail"
 
   # Executes Registry API integration test as a Postman collection with test data (after waiting for data to be loaded)
   reg-api-integration-test-with-wait:

--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -807,7 +807,7 @@
 									"",
 									"var resp = pm.response.json();",
 									"",
-									"pm.test(\"C2723037 file size value does have brackets\", () => {",
+									"pm.test(\"C2723037 file size value doesn't have brackets\", () => {",
 									"    pm.expect(resp[\"pds:File.pds:file_size\"]).to.equal(\"1365\"); ",
 									"});",
 									"",
@@ -855,58 +855,61 @@
 		},
 		{
 			"name": "opensearch requests",
-			"event": [
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"C2723010 legacy_registry index exists\", () => {",
-							"  pm.response.to.have.status(200);",
-							"});",
-							"",
-							"var resp = pm.response.json();",
-							"",
-							"pm.test(\"C2723010 more than 10000 synchronized products\", () => {",
-							"    pm.expect(resp.hits.total.value).to.eql(10000); ",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"auth": {
-					"type": "basic",
-					"basic": [
+					"name": "legacy_registry",
+					"event": [
 						{
-							"key": "password",
-							"value": "admin",
-							"type": "string"
-						},
-						{
-							"key": "username",
-							"value": "admin",
-							"type": "string"
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"C2723010 legacy_registry index exists\", () => {",
+									"  pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var resp = pm.response.json();",
+									"",
+									"pm.test(\"C2723010 more than 10000 synchronized products\", () => {",
+									"    pm.expect(resp.hits.total.value).to.eql(10000); ",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "https://localhost:9200/legacy_registry/_search",
-					"protocol": "https",
-					"host": [
-						"localhost"
 					],
-					"port": "9200",
-					"path": [
-						"legacy_registry",
-						"_search"
-					]
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{opensearchUrl}}/legacy_registry/_search",
+							"host": [
+								"{{opensearchUrl}}"
+							],
+							"path": [
+								"legacy_registry",
+								"_search"
+							]
+						}
+					},
+					"response": []
 				}
-			},
-			"response": []
+			]
 		}
 	],
 	"event": [


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Updates so that the latest postman test collection works with test automation, currently through jenkins with testrail export.

## Test

Once merged the latest test "[Registry API Newman tests via Jenkins" run should be successful on https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/overview/168