### PR TITLE
fix integration test launcher

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       - ${POSTMAN_COLLECTION_FILE}:/postman/postman-collection.json
     networks:
       - pds
-    command: "run /postman/postman-collection.json --env-var baseUrl=${REG_API_URL}"
+    command: "run /postman/postman-collection.json  --insecure --env-var baseUrl=${REG_API_URL} --env-var opensearchUrl=${ES_URL}"
 
   # Executes Registry API integration tests as a Postman collection and reports the results into JPL TestRail
   testrail-reporting-test:


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Since the integration test directly testing the opensearch content, options were missing for the newman run in one case. The options have been added .

That should make the integration test run successfully on a feature branch, with the github action.