### PR TITLE
Add LID Reference to LOLA GDR in GeoSTAC script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ All users and developers of the NASA-PDS software are expected to abide by our [
         * This package is also hosted on the "cheeseshop" and can be installed with
             ```pip install pds.registry```
     * The GeoSTAC utilities can be used to create pds4 labels for the Lola point clouds they host
+    * This command needs LOLA GDR data to be loaded in the registry in order to connect the lid references
+        * This data can be found here: [https://pds-geosciences.wustl.edu/lro/lro-l-lola-3-rdr-v1/lrolol_1xxx/data/lola_gdr/cylindrical/float_img/](https://pds-geosciences.wustl.edu/lro/lro-l-lola-3-rdr-v1/lrolol_1xxx/data/lola_gdr/cylindrical/float_img/)
     * Run the command:
         ```create-lola-pds4```
 

--- a/src/pds/registry/utils/geostac/templates/product-browse-template.xml
+++ b/src/pds/registry/utils/geostac/templates/product-browse-template.xml
@@ -4,11 +4,11 @@ href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1L00.sch" schematypens="http://p
 <Product_Browse>
   <Identification_Area>
     <logical_identifier>
-      {{lid}}
+      {{lid|e}}
     </logical_identifier>
     <version_id>1.0</version_id>
     <title>
-      {{title}}
+      {{title|e}}
     </title>
     <information_model_version>1.21.0.0</information_model_version>
     <product_class>Product_Browse</product_class>
@@ -17,7 +17,7 @@ href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1L00.sch" schematypens="http://p
     <Internal_Reference>
       <!-->lid_reference is incorrect, used as filler right now</-->
       <lid_reference>
-        {{lid_ref}}
+        {{lid_ref|e}}
       </lid_reference>
       <reference_type>browse_to_data</reference_type>
       <comment>
@@ -27,15 +27,15 @@ href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1L00.sch" schematypens="http://p
   </Reference_List>
   <File_Area_Browse>
     <File>
-      <file_name>{{file_name}}</file_name>
+      <file_name>{{file_name|e}}</file_name>
       <local_identifier>BROWSE_FILE</local_identifier>
-      <creation_date_time>{{file_date}}</creation_date_time>
-      <file_URL>{{file_url}}</file_URL>
+      <creation_date_time>{{file_date|e}}</creation_date_time>
+      <file_URL>{{file_url|e}}</file_URL>
     </File>
     <Encoded_Image>
       <local_identifier>BROWSE_IMAGE</local_identifier>
       <offset unit="byte">0</offset>
-      <encoding_standard_id>{{encoding}}</encoding_standard_id>
+      <encoding_standard_id>{{encoding|e}}</encoding_standard_id>
     </Encoded_Image>
   </File_Area_Browse>
 </Product_Browse>

--- a/src/pds/registry/utils/geostac/templates/product-external-template.xml
+++ b/src/pds/registry/utils/geostac/templates/product-external-template.xml
@@ -12,14 +12,14 @@
   http://pds.nasa.gov/pds4/cart/v1 https://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1L00_1970.xsd">
 
   <Identification_Area>
-    <logical_identifier>{{lid}}</logical_identifier>
+    <logical_identifier>{{lid|e}}</logical_identifier>
     <version_id>1.0</version_id>
-    <title>{{title}}</title>
+    <title>{{title|e}}</title>
     <information_model_version>1.21.0.0</information_model_version>
     <product_class>Product_External</product_class>
     <Modification_History>
       <Modification_Detail>
-        <modification_date>{{modification_date}}</modification_date>
+        <modification_date>{{modification_date|e}}</modification_date>
         <version_id>1.0</version_id>
         <description>
           Derived release of the LOLA LIDAR shots in a stretched LAZ/COPC format for streaming services
@@ -39,15 +39,15 @@
     <Discipline_Area>
       <cart:Cartography>
         <Local_Internal_Reference>
-          <local_identifier_reference>{{lid_ref}}</local_identifier_reference>
+          <local_identifier_reference>{{lid_ref|e}}</local_identifier_reference>
           <local_reference_type>cartography_parameters_to_service</local_reference_type>
         </Local_Internal_Reference>
         <cart:Spatial_Domain>
           <cart:Bounding_Coordinates>
-            <cart:west_bounding_coordinate unit="deg">{{bb_west}}</cart:west_bounding_coordinate>
-            <cart:east_bounding_coordinate unit="deg">{{bb_east}}</cart:east_bounding_coordinate>
-            <cart:north_bounding_coordinate unit="deg">{{bb_north}}</cart:north_bounding_coordinate>
-            <cart:south_bounding_coordinate unit="deg">{{bb_south}}</cart:south_bounding_coordinate>
+            <cart:west_bounding_coordinate unit="deg">{{bb_west|e}}</cart:west_bounding_coordinate>
+            <cart:east_bounding_coordinate unit="deg">{{bb_east|e}}</cart:east_bounding_coordinate>
+            <cart:north_bounding_coordinate unit="deg">{{bb_north|e}}</cart:north_bounding_coordinate>
+            <cart:south_bounding_coordinate unit="deg">{{bb_south|e}}</cart:south_bounding_coordinate>
           </cart:Bounding_Coordinates>
         </cart:Spatial_Domain>
         <cart:Spatial_Reference_Information>
@@ -76,9 +76,9 @@
   </Context_Area>
   <File_Area_External>
     <File>
-      <file_name>{{file_name}}</file_name>
-      <local_identifier>{{lid_file}}</local_identifier>
-      <creation_date_time>{{file_date}}</creation_date_time>
+      <file_name>{{file_name|e}}</file_name>
+      <local_identifier>{{lid_file|e}}</local_identifier>
+      <creation_date_time>{{file_date|e}}</creation_date_time>
       <file_URL>{{file_url}}</file_URL>
       <!-- <file_size unit="byte">{{file_size}}</file_size> -->
       <comment>
@@ -96,7 +96,7 @@
   <Reference_List>
     {% for reference in reference_list %}
     <Internal_Reference>
-      <lid_reference>{{reference}}</lid_reference>
+      <lid_reference>{{reference|e}}</lid_reference>
       <reference_type>external_used_to_derive_gridded_data</reference_type>
     </Internal_Reference>
     {% endfor %}

--- a/src/pds/registry/utils/geostac/templates/product-external-template.xml
+++ b/src/pds/registry/utils/geostac/templates/product-external-template.xml
@@ -31,6 +31,10 @@
     <Target_Identification>
 			<name>Moon</name>
 			<type>Satellite</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:target:satellite.earth.moon</lid_reference>
+        <reference_type>data_to_target</reference_type>
+      </Internal_Reference>
 		</Target_Identification>
     <Discipline_Area>
       <cart:Cartography>
@@ -90,10 +94,12 @@
   </File_Area_External>
 
   <Reference_List>
+    {% for reference in reference_list %}
     <Internal_Reference>
-      <lid_reference>urn:nasa:pds:context:target:satellite.earth.moon</lid_reference>
-      <reference_type>data_to_target</reference_type>
+      <lid_reference>{{reference}}</lid_reference>
+      <reference_type>external_used_to_derive_gridded_data</reference_type>
     </Internal_Reference>
+    {% endfor %}
   </Reference_List>
 
 </Product_External>

--- a/src/pds/registry/utils/geostac/templates/product-external-template.xml
+++ b/src/pds/registry/utils/geostac/templates/product-external-template.xml
@@ -88,4 +88,12 @@
       <encoding_standard_id>{{encoding_standard}}</encoding_standard_id>
     </Encoded_External>
   </File_Area_External>
+
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:context:target:satellite.earth.moon</lid_reference>
+      <reference_type>data_to_target</reference_type>
+    </Internal_Reference>
+  </Reference_List>
+
 </Product_External>

--- a/src/pds/registry/utils/treks/create_treks_pds4.py
+++ b/src/pds/registry/utils/treks/create_treks_pds4.py
@@ -105,7 +105,13 @@ def main():
                                         dest=target_dest,
                                         verbose=verbose)
 
-            _, lidvid = psb.create_pds4_xml()
+            service_pds4, lidvid = psb.create_pds4_xml()
+
+            if save_xml:
+                save_path = target_dest + "/" + data["productLabel"].lower() + ".xml"
+                with open(save_path, "w") as f:
+                    f.write(service_pds4)
+
             entry = "P," + lidvid + "\n"
             inventory_entries.append(entry)
 

--- a/src/pds/registry/utils/treks/product_service_builder.py
+++ b/src/pds/registry/utils/treks/product_service_builder.py
@@ -29,6 +29,7 @@ class ProductServiceBuilder:
 
         # get target info
         self.target_type = None
+        self.target_lid = None
         try:
             name = self.target.capitalize()
             pds_query_url = \
@@ -36,6 +37,7 @@ class ProductServiceBuilder:
             response = requests.get(pds_query_url, timeout=30)
             # search type of first hit
             self.target_type = response.json()["data"][0]["properties"]["pds:Target.pds:type"][0]
+            self.target_lid = response.json()["data"][0]["properties"]["lid"][0]
 
         except Exception:
             if self.verbose:
@@ -51,7 +53,7 @@ class ProductServiceBuilder:
         identification_area, lidvid = self.create_identification_area()
         observation_area = self.create_observation_area()
         service = self.create_service()
-        # TODO: add reference list?
+        reference_list = self.create_reference_list()
 
         # create root
         root = Et.Element("Product_Service")
@@ -71,6 +73,7 @@ class ProductServiceBuilder:
         root.append(identification_area)
         root.append(observation_area)
         root.append(service)
+        root.append(reference_list)
 
         tree = Et.ElementTree(root)
 
@@ -388,6 +391,19 @@ class ProductServiceBuilder:
         Et.SubElement(service, "category").text = "Visualization"
 
         return service
+
+    def create_reference_list(self):
+        """Creates Reference_Area for pds4 labeel.
+
+        :return: Reference_List section of pds4 xml
+        """
+        reference_list = Et.Element("Reference_List")
+
+        internal_reference = Et.SubElement(reference_list, "Internal_Reference")
+        Et.SubElement(internal_reference, "lid_reference").text = self.target_lid
+        Et.SubElement(internal_reference, "reference_type").text = "data_to_target"
+
+        return reference_list
 
     def get_fgdc(self):
         """Utility function to get fgdc metadata xml.

--- a/src/pds/registry/utils/treks/templates/product-collection-template.xml
+++ b/src/pds/registry/utils/treks/templates/product-collection-template.xml
@@ -2,9 +2,9 @@
 <Product_Collection xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
 
     <Identification_Area>
-        <logical_identifier>{{lid}}</logical_identifier>
+        <logical_identifier>{{lid|e}}</logical_identifier>
         <version_id>1.0</version_id>
-        <title>{{api_title}}</title>
+        <title>{{api_title|e}}</title>
         <information_model_version>1.22.0.0</information_model_version>
         <product_class>Product_Collection</product_class>
 
@@ -21,7 +21,7 @@
 
     <File_Area_Inventory>
         <File>
-            <file_name>{{inventory_file_name}}</file_name>
+            <file_name>{{inventory_file_name|e}}</file_name>
         </File>
         <Inventory>
             <offset unit="byte">0</offset>

--- a/src/pds/registry/utils/treks/templates/product-service-template.xml
+++ b/src/pds/registry/utils/treks/templates/product-service-template.xml
@@ -1,13 +1,13 @@
 <Product_Service xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cart="http://pds.nasa.gov/pds4/cart/v1" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
 	<Identification_Area>
-		<logical_identifier>{{lid}}</logical_identifier>
-		<version_id>{{vid}}</version_id>
-		<title>{{title}}</title>
+		<logical_identifier>{{lid|e}}</logical_identifier>
+		<version_id>{{vid|e}}</version_id>
+		<title>{{title|e}}</title>
 		<information_model_version>1.22.0.0</information_model_version>
 		<product_class>Product_Service</product_class>
 		<Modification_History>
 			<Modification_Detail>
-				<modification_date>{{modification_date}}</modification_date>
+				<modification_date>{{modification_date|e}}</modification_date>
 				<version_id>1.0</version_id>
 				<description>Exposing GIS services in the PDS4 registry</description>
 			</Modification_Detail>
@@ -15,8 +15,8 @@
 	</Identification_Area>
 	<Observation_Area>
 		<Time_Coordinates>
-			<start_date_time>{{start_time}}</start_date_time>
-			<stop_date_time>{{stop_time}}</stop_date_time>
+			<start_date_time>{{start_time|e}}</start_date_time>
+			<stop_date_time>{{stop_time|e}}</stop_date_time>
 		</Time_Coordinates>
 		<Investigation_Area>
 			<name>Treks Open Geospatial Consortium Web Mapping Tile Service</name>
@@ -29,40 +29,40 @@
 		<Observing_System>
 			{% for component in observing_system_components %}
 			<Observing_System_Component>
-				<name>{{component[0]}}</name>
-				<type>{{component[1]}}</type>
+				<name>{{component[0]|e}}</name>
+				<type>{{component[1]|e}}</type>
 			</Observing_System_Component>
 			{% endfor %}
 		</Observing_System>
 		<Target_Identification>
-			<name>{{target}}</name>
-			<type>{{target_type}}</type>
+			<name>{{target|e}}</name>
+			<type>{{target_type|e}}</type>
 		</Target_Identification>
 		<Discipline_Area>
 			<cart:Cartography>
 				<Local_Internal_Reference>
-					<local_identifier_reference>{{lid_ref}}</local_identifier_reference>
+					<local_identifier_reference>{{lid_ref|e}}</local_identifier_reference>
 					<local_reference_type>cartography_parameters_to_service</local_reference_type>
 				</Local_Internal_Reference>
 				<cart:Spatial_Domain>
 					<cart:Bounding_Coordinates>
-						<cart:west_bounding_coordinate unit="deg">{{bbox_west}}</cart:west_bounding_coordinate>
-						<cart:south_bounding_coordinate unit="deg">{{bbox_south}}</cart:south_bounding_coordinate>
-						<cart:east_bounding_coordinate unit="deg">{{bbox_east}}</cart:east_bounding_coordinate>
-						<cart:north_bounding_coordinate unit="deg">{{bbox_north}}</cart:north_bounding_coordinate>
+						<cart:west_bounding_coordinate unit="deg">{{bbox_west|e}}</cart:west_bounding_coordinate>
+						<cart:south_bounding_coordinate unit="deg">{{bbox_south|e}}</cart:south_bounding_coordinate>
+						<cart:east_bounding_coordinate unit="deg">{{bbox_east|e}}</cart:east_bounding_coordinate>
+						<cart:north_bounding_coordinate unit="deg">{{bbox_north|e}}</cart:north_bounding_coordinate>
 					</cart:Bounding_Coordinates>
 				</cart:Spatial_Domain>
 				<cart:Spatial_Reference_Information>
 					<cart:Horizontal_Coordinate_System_Definition>
 						<cart:Geographic>
-							<cart:latitude_resolution unit="{{unit}}">{{lat_res}}</cart:latitude_resolution>
-							<cart:longitude_resolution unit="{{unit}}">{{lon_res}}</cart:longitude_resolution>
+							<cart:latitude_resolution unit="{{unit}}">{{lat_res|e}}</cart:latitude_resolution>
+							<cart:longitude_resolution unit="{{unit}}">{{lon_res|e}}</cart:longitude_resolution>
 						</cart:Geographic>
 						<cart:Geodetic_Model>
 							<cart:spheroid_name>{{spheroid_name}}</cart:spheroid_name>
-							<cart:a_axis_radius unit="m">{{axis_radius}}</cart:a_axis_radius>
-							<cart:b_axis_radius unit="m">{{axis_radius}}</cart:b_axis_radius>
-							<cart:c_axis_radius unit="m">{{axis_radius}}</cart:c_axis_radius>
+							<cart:a_axis_radius unit="m">{{axis_radius|e}}</cart:a_axis_radius>
+							<cart:b_axis_radius unit="m">{{axis_radius|e}}</cart:b_axis_radius>
+							<cart:c_axis_radius unit="m">{{axis_radius|e}}</cart:c_axis_radius>
 						</cart:Geodetic_Model>
 					</cart:Horizontal_Coordinate_System_Definition>
 				</cart:Spatial_Reference_Information>
@@ -70,18 +70,18 @@
 		</Discipline_Area>
 	</Observation_Area>
 	<Service>
-		<name>{{name}}</name>
-		<abstract_desc>{{abstract}}</abstract_desc>
-		<url>{{capabilities_url}}</url>
-		<url>{{fgdc_url}}</url>
-		<url>{{gui_url}}</url>
-		<release_date>{{release_date}}</release_date>
+		<name>{{name|e}}</name>
+		<abstract_desc>{{abstract|e}}</abstract_desc>
+		<url>{{capabilities_url|e}}</url>
+		<url>{{fgdc_url|e}}</url>
+		<url>{{gui_url|e}}</url>
+		<release_date>{{release_date|e}}</release_date>
 		<service_type>OGC WMTS</service_type>
 		<category>Visualization</category>
 	</Service>
 	<Reference_List>
 		<Internal_Reference>
-			<lid_reference>{{target_lid}}</lid_reference>
+			<lid_reference>{{target_lid|e}}</lid_reference>
 			<reference_type>data_to_target</reference_type>
 		</Internal_Reference>
 	</Reference_List>

--- a/src/pds/registry/utils/treks/templates/product-service-template.xml
+++ b/src/pds/registry/utils/treks/templates/product-service-template.xml
@@ -1,0 +1,88 @@
+<Product_Service xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cart="http://pds.nasa.gov/pds4/cart/v1" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
+	<Identification_Area>
+		<logical_identifier>{{lid}}</logical_identifier>
+		<version_id>{{vid}}</version_id>
+		<title>{{title}}</title>
+		<information_model_version>1.22.0.0</information_model_version>
+		<product_class>Product_Service</product_class>
+		<Modification_History>
+			<Modification_Detail>
+				<modification_date>{{modification_date}}</modification_date>
+				<version_id>1.0</version_id>
+				<description>Exposing GIS services in the PDS4 registry</description>
+			</Modification_Detail>
+		</Modification_History>
+	</Identification_Area>
+	<Observation_Area>
+		<Time_Coordinates>
+			<start_date_time>{{start_time}}</start_date_time>
+			<stop_date_time>{{stop_time}}</stop_date_time>
+		</Time_Coordinates>
+		<Investigation_Area>
+			<name>Treks Open Geospatial Consortium Web Mapping Tile Service</name>
+			<type>OGC WMTS</type>
+			<Internal_Reference>
+				<lid_reference>urn:nasa:pds:ogc:wmts</lid_reference>
+				<reference_type>lid_reference</reference_type>
+			</Internal_Reference>
+		</Investigation_Area>
+		<Observing_System>
+			{% for component in observing_system_components %}
+			<Observing_System_Component>
+				<name>{{component[0]}}</name>
+				<type>{{component[1]}}</type>
+			</Observing_System_Component>
+			{% endfor %}
+		</Observing_System>
+		<Target_Identification>
+			<name>{{target}}</name>
+			<type>{{target_type}}</type>
+		</Target_Identification>
+		<Discipline_Area>
+			<cart:Cartography>
+				<Local_Internal_Reference>
+					<local_identifier_reference>{{lid_ref}}</local_identifier_reference>
+					<local_reference_type>cartography_parameters_to_service</local_reference_type>
+				</Local_Internal_Reference>
+				<cart:Spatial_Domain>
+					<cart:Bounding_Coordinates>
+						<cart:west_bounding_coordinate unit="deg">{{bbox_west}}</cart:west_bounding_coordinate>
+						<cart:south_bounding_coordinate unit="deg">{{bbox_south}}</cart:south_bounding_coordinate>
+						<cart:east_bounding_coordinate unit="deg">{{bbox_east}}</cart:east_bounding_coordinate>
+						<cart:north_bounding_coordinate unit="deg">{{bbox_north}}</cart:north_bounding_coordinate>
+					</cart:Bounding_Coordinates>
+				</cart:Spatial_Domain>
+				<cart:Spatial_Reference_Information>
+					<cart:Horizontal_Coordinate_System_Definition>
+						<cart:Geographic>
+							<cart:latitude_resolution unit="{{unit}}">{{lat_res}}</cart:latitude_resolution>
+							<cart:longitude_resolution unit="{{unit}}">{{lon_res}}</cart:longitude_resolution>
+						</cart:Geographic>
+						<cart:Geodetic_Model>
+							<cart:spheroid_name>{{spheroid_name}}</cart:spheroid_name>
+							<cart:a_axis_radius unit="m">{{axis_radius}}</cart:a_axis_radius>
+							<cart:b_axis_radius unit="m">{{axis_radius}}</cart:b_axis_radius>
+							<cart:c_axis_radius unit="m">{{axis_radius}}</cart:c_axis_radius>
+						</cart:Geodetic_Model>
+					</cart:Horizontal_Coordinate_System_Definition>
+				</cart:Spatial_Reference_Information>
+			</cart:Cartography>
+		</Discipline_Area>
+	</Observation_Area>
+	<Service>
+		<name>{{name}}</name>
+		<abstract_desc>{{abstract}}</abstract_desc>
+		<url>{{capabilities_url}}</url>
+		<url>{{fgdc_url}}</url>
+		<url>{{gui_url}}</url>
+		<release_date>{{release_date}}</release_date>
+		<service_type>OGC WMTS</service_type>
+		<category>Visualization</category>
+	</Service>
+	<Reference_List>
+		<Internal_Reference>
+			<lid_reference>{{target_lid}}</lid_reference>
+			<reference_type>data_to_target</reference_type>
+		</Internal_Reference>
+	</Reference_List>
+</Product_Service>


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Added references to GDR LOLA data into the GeoSTAC script. The data is considered derived from if their bounding boxes overlap. Also, per Sean's worry of invalid characters, it's also been fixed by adding a pipe to  encode characters such as & and <, >.

## ⚙️ Test Data and/or Report
The labels are able to build and load into the registry.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #316 



