### PR TITLE
Fix code scanning alert no. 24: Jinja2 templating with autoescape=False

### DIFF
--- a/src/pds/registry/utils/geostac/create_lola_pds4.py
+++ b/src/pds/registry/utils/geostac/create_lola_pds4.py
@@ -2,16 +2,17 @@
 import argparse
 import importlib
 import logging
-import os
 from datetime import date
 from pathlib import Path
 
 import requests
-from jinja2 import Environment, select_autoescape
+from jinja2 import Environment
+from jinja2 import select_autoescape
 from pds.registry.utils.geostac import templates
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def check_for_overlap(bbox1, bbox2):
     """Checks if bounding boxes overlap anywhere.
@@ -93,7 +94,7 @@ def create_product_external(item):
         item_title = item["assets"]["data"]["title"]
 
         last_slash_i = item["assets"]["data"]["href"].rfind("/")
-        file = "data/" +item["assets"]["data"]["href"][last_slash_i + 1:]
+        file = "data/" + item["assets"]["data"]["href"][last_slash_i + 1:]
         logger.info(f'file is on {item["assets"]["data"]["href"]},fake file is on {file}')
         open("lola_xml/product_external/" + file, 'a').close()
 

--- a/src/pds/registry/utils/geostac/create_lola_pds4.py
+++ b/src/pds/registry/utils/geostac/create_lola_pds4.py
@@ -7,7 +7,7 @@ from datetime import date
 from pathlib import Path
 
 import requests
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from pds.registry.utils.geostac import templates
 
 logging.basicConfig(level=logging.INFO)
@@ -85,7 +85,7 @@ def create_product_external(item):
     :return: pds4 xml
     """
     # create env
-    env = Environment()
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
     with importlib.resources.open_text(templates, "product-external-template.xml") as io:
         template_text = io.read()
         template = env.from_string(template_text)
@@ -143,7 +143,7 @@ def create_product_browse(item):
     :return: pds4 xml
     """
     # create env
-    env = Environment()
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
 
     with importlib.resources.open_text(templates, "product-browse-template.xml") as io:
         template_text = io.read()


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry/security/code-scanning/24](https://github.com/NASA-PDS/registry/security/code-scanning/24)

To fix the problem, we need to ensure that the Jinja2 `Environment` object is created with `autoescape` enabled. This can be done by using the `select_autoescape` function, which will automatically enable autoescaping for specific file extensions like HTML and XML. This change will prevent XSS attacks by escaping any untrusted input rendered in the templates.

We need to modify the creation of the `Environment` object in the `create_product_external` and `create_product_browse` functions to include `autoescape=select_autoescape(['html', 'xml'])`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
