### PR TITLE
Fix code scanning alert no. 20: Jinja2 templating with autoescape=False

### DIFF
--- a/src/pds/registry/utils/treks/product_service_builder.py
+++ b/src/pds/registry/utils/treks/product_service_builder.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as Et
 from datetime import date
 
 import requests
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from pds.registry.utils.treks import templates
 
 
@@ -60,7 +60,7 @@ class ProductServiceBuilder:
         self.create_reference_list()
 
         # create env
-        env = Environment()
+        env = Environment(autoescape=select_autoescape(['html', 'xml']))
 
         # get template
         with importlib.resources.open_text(templates, "product-service-template.xml") as io:


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry/security/code-scanning/20](https://github.com/NASA-PDS/registry/security/code-scanning/20)

To fix the problem, we need to ensure that the Jinja2 environment is created with auto-escaping enabled. This can be done by using the `select_autoescape` function provided by Jinja2, which automatically enables escaping for specific file extensions like HTML and XML. This change will prevent potential XSS vulnerabilities by escaping any untrusted input rendered in the template.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
