### PR TITLE
Fix code scanning alert no. 19: Jinja2 templating with autoescape=False

### DIFF
--- a/src/pds/registry/utils/geostac/create_lola_pds4.py
+++ b/src/pds/registry/utils/geostac/create_lola_pds4.py
@@ -7,7 +7,7 @@ from datetime import date
 from pathlib import Path
 
 import requests
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from pds.registry.utils.geostac import templates
 
 logging.basicConfig(level=logging.INFO)
@@ -85,7 +85,7 @@ def create_product_external(item):
     :return: pds4 xml
     """
     # create env
-    env = Environment()
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
     with importlib.resources.open_text(templates, "product-external-template.xml") as io:
         template_text = io.read()
         template = env.from_string(template_text)
@@ -143,7 +143,7 @@ def create_product_browse(item):
     :return: pds4 xml
     """
     # create env
-    env = Environment()
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
 
     with importlib.resources.open_text(templates, "product-browse-template.xml") as io:
         template_text = io.read()


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry/security/code-scanning/19](https://github.com/NASA-PDS/registry/security/code-scanning/19)

To fix the problem, we need to ensure that the Jinja2 `Environment` object is created with `autoescape` set to `True`. This can be done by using the `select_autoescape` function, which will automatically enable autoescaping for specific file extensions like HTML and XML. This change will prevent XSS attacks by escaping untrusted input in the templates.

We need to modify the creation of the `Environment` object in the `create_product_external` and `create_product_browse` functions to include the `autoescape` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
