### PR TITLE
Fix code scanning alert no. 17: Jinja2 templating with autoescape=False

### DIFF
--- a/src/pds/registry/utils/geostac/create_lola_pds4.py
+++ b/src/pds/registry/utils/geostac/create_lola_pds4.py
@@ -6,7 +6,8 @@ from datetime import date
 from pathlib import Path
 
 import requests
-from jinja2 import Environment, select_autoescape
+from jinja2 import Environment
+from jinja2 import select_autoescape
 from pds.registry.utils.geostac import templates
 
 logging.basicConfig(level=logging.INFO)

--- a/src/pds/registry/utils/treks/product_collection_builder.py
+++ b/src/pds/registry/utils/treks/product_collection_builder.py
@@ -1,7 +1,7 @@
 """Utility for creating Product_Collection PDS4 xml."""
 import importlib.resources
 
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 from pds.registry.utils.treks import templates
 
 
@@ -13,7 +13,7 @@ def create_collection_pds4(target):
     :return: Product_Collection PDS4 xml
     """
     # create env
-    env = Environment()
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
 
     with importlib.resources.open_text(templates, "product-collection-template.xml") as io:
         template_text = io.read()

--- a/src/pds/registry/utils/treks/product_service_builder.py
+++ b/src/pds/registry/utils/treks/product_service_builder.py
@@ -5,7 +5,8 @@ import xml.etree.ElementTree as Et
 from datetime import date
 
 import requests
-from jinja2 import Environment, select_autoescape
+from jinja2 import Environment
+from jinja2 import select_autoescape
 from pds.registry.utils.treks import templates
 
 


### PR DESCRIPTION
Fixes [https://github.com/NASA-PDS/registry/security/code-scanning/17](https://github.com/NASA-PDS/registry/security/code-scanning/17)

To fix the problem, we need to ensure that the Jinja2 environment is created with autoescaping enabled. This can be done by using the `select_autoescape` function provided by Jinja2, which will automatically enable autoescaping for HTML and XML templates. This change will prevent XSS attacks by escaping any untrusted input rendered in the templates.

We will modify the creation of the `Environment` object on line 16 to include the `autoescape` parameter with the `select_autoescape` function. This change will be made in the file `src/pds/registry/utils/treks/product_collection_builder.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Closes https://github.com/NASA-PDS/registry/pull/343
Closes https://github.com/NASA-PDS/registry/pull/342
