### PR TITLE
implement test for NASA-PDS/registry-api#630

### DIFF
--- a/docker/postman/postman_collection.json
+++ b/docker/postman/postman_collection.json
@@ -3300,6 +3300,55 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "NASA-PDS/registry-api#630 As a user, I want the total number of products returned to match both the total number of products expected to be loaded and the total number of products that were loaded",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const testrailId = \"C4494388\";",
+									"pm.test(`${testrailId} Status code is 200`, () => {",
+									"  pm.response.to.have.status(200);",
+									"});",
+									"",
+									"const content = pm.response.json();",
+									"pm.test(\"Expected hits count returned\", function () {",
+									"   pm.expect(content.summary.hits).to.eql(38)",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"accept": true
+						}
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/products",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"products"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,28 +60,28 @@ python_requires = >= 3.9
 
 [options.extras_require]
 dev =
-    black
+    black~=23.7.0
     docutils==0.16
-    flake8
-    flake8-bugbear
-    flake8-docstrings
+    flake8~=6.1.0
+    flake8-bugbear~=23.7.10
+    flake8-docstrings~=1.7.0
     Jinja2==3.1.4
-    pep8-naming
-    mypy
-    pydocstyle
-    coverage
-    pytest
-    pytest-cov
-    pytest-watch
-    pytest-xdist
-    pre-commit
-    sphinx
-    sphinx-rtd-theme
-    sphinxcontrib-openapi
-    sphinxcontrib-redoc
-    tox
+    pep8-naming~=0.13.3
+    mypy~=1.5.1
+    pydocstyle~=6.3.0
+    coverage~=7.3.0
+    pytest~=7.4.0
+    pytest-cov~=4.1.0
+    pytest-watch~=4.2.0
+    pytest-xdist~=3.3.1
+    pre-commit~=3.3.3
+    sphinx~=5.3.0
+    sphinx-rtd-theme~=0.5.0
+    sphinxcontrib-openapi~=0.8.4
+    sphinxcontrib-redoc~=1.6.0
+    tox~=4.11.0
+    types-setuptools~=68.1.0.0
     types-requests==2.32.0.20241016
-    types-setuptools
     types-pkg_resources==0.1.3
 
 [options.entry_points]


### PR DESCRIPTION
## 🗒️ Summary
Implements a test that the number of total hits for _search is exactly equal to the expected number.
Assumes that the current count of 38 is correct - @jordanpadams is that a valid assumption?

## ⚙️ Test Data and/or Report
Test passes (Postman, dockerized registry)

## ♻️ Related Issues
https://github.com/NASA-PDS/registry-api/issues/630#issuecomment-2779638308