### PR TITLE
Prototype terraform for provisioned opensearch

### DIFF
--- a/terraform/opensearch/index_templates/main.tf
+++ b/terraform/opensearch/index_templates/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+    bucket = "pds-prod-infra"
+    key    = "provisioned_opensearch/opensearch_index_templates.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+# Load external JSON files
+locals {
+  index_templates = jsondecode(file("${var.template_file_pathname}"))
+}
+
+resource "opensearch_composable_index_template" "pds_index_templates" {
+  for_each = local.index_templates
+
+  name = each.key
+  body = jsonencode({
+    index_patterns = each.value.index_pattern
+    priority       = each.value.priority
+    template = {
+      settings = {
+          "index.number_of_shards"   = each.value.shards
+          "index.number_of_replicas" = each.value.replicas
+      }
+    }
+  })
+}
+

--- a/terraform/opensearch/index_templates/main.tf
+++ b/terraform/opensearch/index_templates/main.tf
@@ -22,6 +22,7 @@ resource "opensearch_composable_index_template" "pds_index_templates" {
     priority       = each.value.priority
     template = {
       settings = each.value.settings
+      aliases = each.value.aliases
     }
   })
 }

--- a/terraform/opensearch/index_templates/main.tf
+++ b/terraform/opensearch/index_templates/main.tf
@@ -21,10 +21,7 @@ resource "opensearch_composable_index_template" "pds_index_templates" {
     index_patterns = each.value.index_pattern
     priority       = each.value.priority
     template = {
-      settings = {
-          "index.number_of_shards"   = each.value.shards
-          "index.number_of_replicas" = each.value.replicas
-      }
+      settings = each.value.settings
     }
   })
 }

--- a/terraform/opensearch/index_templates/provider.tf
+++ b/terraform/opensearch/index_templates/provider.tf
@@ -3,6 +3,15 @@
 #
 # Amazon Web Services: the basics.
 
+terraform {
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = "2.3.2"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 
@@ -15,4 +24,8 @@ provider "aws" {
       cicd      = var.cicd
     }
   }
+}
+
+provider "opensearch" {
+  url = "${var.opensearch_url}"
 }

--- a/terraform/opensearch/index_templates/provider.tf
+++ b/terraform/opensearch/index_templates/provider.tf
@@ -1,8 +1,3 @@
-# AWS
-# ===
-#
-# Amazon Web Services: the basics.
-
 terraform {
   required_providers {
     opensearch = {

--- a/terraform/opensearch/index_templates/provider.tf
+++ b/terraform/opensearch/index_templates/provider.tf
@@ -1,0 +1,18 @@
+# AWS
+# ===
+#
+# Amazon Web Services: the basics.
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      tenant    = var.tenant
+      venue     = var.venue
+      component = var.component
+      managedBy = var.managedBy
+      cicd      = var.cicd
+    }
+  }
+}

--- a/terraform/opensearch/index_templates/variables.tf
+++ b/terraform/opensearch/index_templates/variables.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {
+  type        = string
+  description = "Effective AWS Region"
+  default     = "us-west-2"
+}
+
+variable "template_file_pathname" {
+  type        = string
+  description = "Full path to the index template file."
+}
+
+variable "venue" {
+  type        = string
+  description = "Tag value of venue"
+}
+
+variable "tenant" {
+  type        = string
+  description = "Tag value of tenant"
+  default     = "en"
+}
+
+variable "component" {
+  type        = string
+  description = "Tag value of component"
+  default     = "registry"
+}
+
+variable "cicd" {
+  type        = string
+  description = "Tag value of CICD deployment method"
+  default     = "terraform"
+}
+
+variable "managedBy" {
+  type        = string
+  description = "Tag value for owner managing the resource (E.g. for PDS Team we have PDS Team Email Distro)"
+  default     = "pdsoperator@jpl.nasa.gov"
+}

--- a/terraform/opensearch/index_templates/variables.tf
+++ b/terraform/opensearch/index_templates/variables.tf
@@ -4,6 +4,11 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "opensearch_url" {
+  type        = string
+  description = "Opensearch endpoint URL"
+}
+
 variable "template_file_pathname" {
   type        = string
   description = "Full path to the index template file."

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -84,7 +84,9 @@ data "aws_iam_policy_document" "domain_access_policy_document" {
 }
 
 resource "aws_opensearch_domain_policy" "domain_access_policy" {
-  domain_name = "${var.domain_name}"
+  domain_name     = "${var.domain_name}"
   access_policies = data.aws_iam_policy_document.domain_access_policy_document.json
+
+  depends_on = [aws_opensearch_domain.pds-opensearch-domain]
 }
 

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -1,0 +1,82 @@
+data "aws_caller_identity" "current" {}
+
+# Load external JSON files
+locals {
+  access_policies = jsondecode(file("${path.module}/policies/${var.venue}/data.json"))
+}
+
+resource "aws_opensearch_domain" "pds-opensearch-domain" {
+  domain_name    = "${var.domain_name}"
+  engine_version = "OpenSearch_2.17"
+
+  cluster_config {
+    instance_type  = "${var.data_node_instance_type}"
+    instance_count = ${var.data_node_count} 
+
+    # 3 x m6g.large.search dedicated master nodes
+    dedicated_master_enabled = true
+    dedicated_master_type    = "${var.master_node_instance_type}"
+    dedicated_master_count   = ${var.master_node_count}
+
+    # Multi-AZ is required for 3 dedicated master nodes to ensure HA
+    zone_awareness_enabled = true
+    zone_awareness_config {
+      availability_zone_count = 3
+    }
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_type = "gp3"
+    # EBS volume size is specified in GB per data node
+    volume_size = $var.ebs_volume_gb
+  }
+
+  encrypt_at_rest {
+    enabled = true
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+}
+
+data "aws_iam_policy_document" "domain_access_policy_document" {
+  description = "Data access policies to define access to ${var.domain_name}"
+
+  policy = jsonencode({
+    "Version"   = "2012-10-17",
+    "Statement" = [
+      for statement in local.access_policies.Statememts : {
+        Sid         = statement.Sid,
+        Effect      = statement.Effect,
+        Action      = statement.Action,
+        Resource    = [
+          for resource in statement.Resource : 
+            replace(
+              replace(
+                replace(
+                  resource, 
+                  "{account_id}". data.aws_caller_identity.current.account_id
+                ),
+                "{region}", "${var.region}"
+              ),
+              "{domain_name}", "${var.domain_name}"
+            )
+        ],
+        Principal   = [for principal in rule.Principal : replace(principal, "{account_id}", data.aws_caller_identity.current.account_id)]
+      }
+    ]
+  })
+}
+
+resource "aws_opensearch_domain_policy" "domain_access_policy" {
+  domain_name = "${var.domain_name}"
+  access_policies = data.aws_iam_policy_document.domain_access_policy_document
+}
+

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "pds-prod-infra"
+    key    = "provisioned_opensearch/provisioned_opensearch.tfstate"
+    region = "us-west-2"
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 # Load external JSON files
@@ -11,12 +19,12 @@ resource "aws_opensearch_domain" "pds-opensearch-domain" {
 
   cluster_config {
     instance_type  = "${var.data_node_instance_type}"
-    instance_count = ${var.data_node_count} 
+    instance_count = var.data_node_count
 
     # 3 x m6g.large.search dedicated master nodes
     dedicated_master_enabled = true
     dedicated_master_type    = "${var.master_node_instance_type}"
-    dedicated_master_count   = ${var.master_node_count}
+    dedicated_master_count   = var.master_node_count
 
     # Multi-AZ is required for 3 dedicated master nodes to ensure HA
     zone_awareness_enabled = true
@@ -27,17 +35,17 @@ resource "aws_opensearch_domain" "pds-opensearch-domain" {
 
   ebs_options {
     ebs_enabled = true
-    volume_type = "gp3"
+    volume_type = "${var.ebs_volume_type}"
     # EBS volume size is specified in GB per data node
-    volume_size = $var.ebs_volume_gb
+    volume_size = var.ebs_volume_gb
   }
 
   encrypt_at_rest {
-    enabled = true
+    enabled = var.encryption_at_rest
   }
 
   node_to_node_encryption {
-    enabled = true
+    enabled = var.n2n_encryption
   }
 
   domain_endpoint_options {
@@ -47,36 +55,36 @@ resource "aws_opensearch_domain" "pds-opensearch-domain" {
 }
 
 data "aws_iam_policy_document" "domain_access_policy_document" {
-  description = "Data access policies to define access to ${var.domain_name}"
+  dynamic "statement" {
+    for_each = local.access_policies
 
-  policy = jsonencode({
-    "Version"   = "2012-10-17",
-    "Statement" = [
-      for statement in local.access_policies.Statememts : {
-        Sid         = statement.Sid,
-        Effect      = statement.Effect,
-        Action      = statement.Action,
-        Resource    = [
-          for resource in statement.Resource : 
+    content {
+      sid         = statement.value.Sid
+      effect      = statement.value.Effect
+      actions     = statement.value.Action
+      resources   = [
+        for resource in statement.value.Resource : 
+          replace(
             replace(
               replace(
-                replace(
-                  resource, 
-                  "{account_id}". data.aws_caller_identity.current.account_id
-                ),
-                "{region}", "${var.region}"
+                resource, 
+                "{account_id}", data.aws_caller_identity.current.account_id
               ),
-              "{domain_name}", "${var.domain_name}"
-            )
-        ],
-        Principal   = [for principal in rule.Principal : replace(principal, "{account_id}", data.aws_caller_identity.current.account_id)]
+              "{region}", "${var.aws_region}"
+            ),
+            "{domain_name}", "${var.domain_name}"
+          )
+      ]
+      principals {
+          type        = "AWS"
+          identifiers = [ for principal in statement.value.Principal : replace(principal, "{account_id}", data.aws_caller_identity.current.account_id) ]
       }
-    ]
-  })
+    }
+  }
 }
 
 resource "aws_opensearch_domain_policy" "domain_access_policy" {
   domain_name = "${var.domain_name}"
-  access_policies = data.aws_iam_policy_document.domain_access_policy_document
+  access_policies = data.aws_iam_policy_document.domain_access_policy_document.json
 }
 

--- a/terraform/opensearch/main.tf
+++ b/terraform/opensearch/main.tf
@@ -10,7 +10,7 @@ data "aws_caller_identity" "current" {}
 
 # Load external JSON files
 locals {
-  access_policies = jsondecode(file("${path.module}/policies/${var.venue}/data.json"))
+  access_policies = jsondecode(file("${var.policy_json_file}"))
 }
 
 resource "aws_opensearch_domain" "pds-opensearch-domain" {

--- a/terraform/opensearch/osi_pipeline/main.tf
+++ b/terraform/opensearch/osi_pipeline/main.tf
@@ -7,15 +7,23 @@ terraform {
 }
 
 resource "aws_osis_pipeline" "pds_osi_pipeline" {
-  pipeline_name              = "${var.pipeline_name}"
+  pipeline_name               = "${var.pipeline_name}"
   pipeline_configuration_body = file("${var.pipeline_config_yaml_file}")
-      max_units                  = var.pipeline_max_units
-      min_units                  = var.pipeline_min_units 
+  pipeline_role_arn           = "{var.pipeline_role_arn}"
+
+  max_units                   = var.pipeline_max_units
+  min_units                   = var.pipeline_min_units 
 
   log_publishing_options {
     is_logging_enabled = true
     cloudwatch_log_destination {
-      log_group = "/aws/vendedlogs/OpenSearchService/ingestion/${var.pipeline_name}"
+      log_group = "${var.cloudwatch_log_group}"
     }
+  }
+
+  vpc_options {
+    subnet_ids              = [ "${var.subnet_ids}" ]
+    security_group_ids      = [ "${var.security_group_ids}" ]
+    vpc_endpoint_management = "${var.vpc_endpoint_management}"
   }
 }

--- a/terraform/opensearch/osi_pipeline/main.tf
+++ b/terraform/opensearch/osi_pipeline/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  backend "s3" {
+    bucket = "pds-prod-infra"
+    key    = "provisioned_opensearch/osi_pipeline.tfstate"
+    region = "us-west-2"
+  }
+}
+
+resource "aws_osis_pipeline" "pds_osi_pipeline" {
+  pipeline_name              = "${var.pipeline_name}""
+  pipeline_configuration_body = <<EOF
+
+    version: '2'
+    extension:
+      osis_configuration_metadata:
+        builder_type: visual
+    pds-dev-test-pipeline:
+      source:
+        opensearch:
+          acknowledgments: true
+          hosts:
+            - '${var.source_opensearch_uri}'
+          aws:
+            serverless: var.source_opensearch_serverless
+            region: var.aws_region
+            serverless_options:
+              network_policy_name: ''
+          indices:
+             include:
+               - index_name_regex: '*'
+          search_options:
+            batch_size: '${var.source_batch_size}''
+      processor: []
+      sink:
+        - opensearch:
+            hosts:
+              - '${var.sink_opensearch_uri}'
+            aws:
+              serverless: var.sink_opensearch_serverless
+              region: var.aws_region
+            index_type: custom
+            index: '${getMetadata("opensearch-index")}'
+            document_id: '${getMetadata("opensearch-document_id")}'
+      max_units                  = var.pipeline_max_units
+      min_units                  = var.pipeline_min_units 
+
+EOF
+
+  log_publishing_options {
+    is_logging_enabled = true
+    cloudwatch_log_destination {
+      log_group = "/aws/vendedlogs/OpenSearchService/ingestion/${var.pipeline_name}"
+    }
+  }
+}

--- a/terraform/opensearch/osi_pipeline/main.tf
+++ b/terraform/opensearch/osi_pipeline/main.tf
@@ -9,7 +9,7 @@ terraform {
 resource "aws_osis_pipeline" "pds_osi_pipeline" {
   pipeline_name               = "${var.pipeline_name}"
   pipeline_configuration_body = file("${var.pipeline_config_yaml_file}")
-  pipeline_role_arn           = "{var.pipeline_role_arn}"
+  pipeline_role_arn           = "${var.pipeline_role_arn}"
 
   max_units                   = var.pipeline_max_units
   min_units                   = var.pipeline_min_units 

--- a/terraform/opensearch/osi_pipeline/main.tf
+++ b/terraform/opensearch/osi_pipeline/main.tf
@@ -8,41 +8,7 @@ terraform {
 
 resource "aws_osis_pipeline" "pds_osi_pipeline" {
   pipeline_name              = "${var.pipeline_name}"
-  pipeline_configuration_body = <<EOF
-
-    version: '2'
-    extension:
-      osis_configuration_metadata:
-        builder_type: visual
-    pds-dev-test-pipeline:
-      source:
-        opensearch:
-          acknowledgments: true
-          hosts:
-            - '${var.source_opensearch_url}'
-          aws:
-            serverless: ${var.source_opensearch_serverless}
-            region: '${var.aws_region}'
-            serverless_options:
-              network_policy_name: ''
-          indices:
-             include:
-               - index_name_regex: '*'
-          search_options:
-            batch_size: ${var.source_batch_size}
-      processor: []
-      sink:
-        - opensearch:
-            hosts:
-              - '${var.sink_opensearch_url}'
-            aws:
-              serverless: ${var.sink_opensearch_serverless}
-              region: '${var.aws_region}'
-              sts_role_arn: '${var.pipeline_role_arn}'
-            index_type: custom
-            index: "${getMetadata("opensearch-index")}"
-            document_id: "${getMetadata("opensearch-document_id")}"
-EOF
+  pipeline_configuration_body = file("${var.pipeline_config_yaml_file}")
       max_units                  = var.pipeline_max_units
       min_units                  = var.pipeline_min_units 
 

--- a/terraform/opensearch/osi_pipeline/main.tf
+++ b/terraform/opensearch/osi_pipeline/main.tf
@@ -7,7 +7,7 @@ terraform {
 }
 
 resource "aws_osis_pipeline" "pds_osi_pipeline" {
-  pipeline_name              = "${var.pipeline_name}""
+  pipeline_name              = "${var.pipeline_name}"
   pipeline_configuration_body = <<EOF
 
     version: '2'
@@ -19,32 +19,32 @@ resource "aws_osis_pipeline" "pds_osi_pipeline" {
         opensearch:
           acknowledgments: true
           hosts:
-            - '${var.source_opensearch_uri}'
+            - '${var.source_opensearch_url}'
           aws:
-            serverless: var.source_opensearch_serverless
-            region: var.aws_region
+            serverless: ${var.source_opensearch_serverless}
+            region: '${var.aws_region}'
             serverless_options:
               network_policy_name: ''
           indices:
              include:
                - index_name_regex: '*'
           search_options:
-            batch_size: '${var.source_batch_size}''
+            batch_size: ${var.source_batch_size}
       processor: []
       sink:
         - opensearch:
             hosts:
-              - '${var.sink_opensearch_uri}'
+              - '${var.sink_opensearch_url}'
             aws:
-              serverless: var.sink_opensearch_serverless
-              region: var.aws_region
+              serverless: ${var.sink_opensearch_serverless}
+              region: '${var.aws_region}'
+              sts_role_arn: '${var.pipeline_role_arn}'
             index_type: custom
-            index: '${getMetadata("opensearch-index")}'
-            document_id: '${getMetadata("opensearch-document_id")}'
+            index: "${getMetadata("opensearch-index")}"
+            document_id: "${getMetadata("opensearch-document_id")}"
+EOF
       max_units                  = var.pipeline_max_units
       min_units                  = var.pipeline_min_units 
-
-EOF
 
   log_publishing_options {
     is_logging_enabled = true

--- a/terraform/opensearch/osi_pipeline/provider.tf
+++ b/terraform/opensearch/osi_pipeline/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      tenant      = var.tenant
+      venue       = var.venue
+      component   = var.component
+      cicd        = var.cicd
+      managedby   = var.managedBy
+    }
+  }
+}

--- a/terraform/opensearch/osi_pipeline/variables.tf
+++ b/terraform/opensearch/osi_pipeline/variables.tf
@@ -13,6 +13,11 @@ variable "pipeline_config_yaml_file" {
   description = "Full path to the pipeline config yaml file."
 }
 
+variable "pipeline_role_arn" {
+  type        = string
+  description = "ARN of the pipeline role."
+}
+
 variable "pipeline_max_units" {
   type        = number
   description = "Maximum number of pipeline ingestion units."
@@ -22,6 +27,26 @@ variable "pipeline_min_units" {
   type        = number
   description = "Minimum number of pipeline ingestion units. Default = 1."
   default     = 1
+}
+
+variable "cloudwatch_log_group" {
+  type        = string
+  description = "Log group for pipeline logging."
+}
+
+variable "subnet_ids" {
+  type        = string
+  description = "Subnet through which to access the pipeline."
+}
+
+variable "security_group_ids" {
+  type        = string
+  description = "Security group associated with the endpoint."
+}
+
+variable "vpc_endpoint_management" {
+  type        = string
+  description = "CUSTOMER or SERVICE - who is managing the vpc endpoint."
 }
 
 variable "venue" {

--- a/terraform/opensearch/osi_pipeline/variables.tf
+++ b/terraform/opensearch/osi_pipeline/variables.tf
@@ -1,0 +1,77 @@
+variable "aws_region" {
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "pipeline_name" {
+  type        = string
+  description = "Name of the pipeline (also the cloudwatch log group"
+}
+
+variable "source_opensearch_url" {
+  type        = string
+  description = "URI of the source opensearch endpoint."
+}
+
+variable "source_opensearch_serverless" {
+  type        = boolean
+  description = "Boolean indicating if source is AOSS. Default is true."
+  default     = true
+}
+
+variable "source_batch_size" {
+  type        = string
+  description = "Size of the source batch reads"
+  default     = '1000'
+}
+
+variable "sink_opensearch_url" {
+  type        = string
+  description = "URI of the sink opensearch endpoint."
+}
+
+variable "sink_opensearch_serverless" {
+  type        = boolean
+  description = "Boolean indicating if sink is AOSS. Default is false."
+  default     = false
+}
+
+variable "pipeline_max_units" {
+  type        = number
+  description = "Maximum number of pipeline ingestion units."
+}
+
+variable "pipeline_min_units: {
+  type        = number
+  description = "Minimum number of pipeline ingestion units. Default = 1."
+  default     = 1
+}
+
+variable "aws_venue" {
+  type        = string
+  description = "Tag value of venue"
+}
+
+variable "tenant" {
+  type        = string
+  description = "Tag value of tenant"
+  default     = "en"
+}
+
+variable "component" {
+  type        = string
+  description = "Tag value of component"
+  default     = "registry"
+}
+
+variable "cicd" {
+  type        = string
+  description = "Tag value of CICD deployment method"
+  default     = "terraform"
+}
+
+variable "managedBy" {
+  type        = string
+  description = "Tag value for owner managing the resource (E.g. for PDS Team we have PDS Team Email Distro)"
+  default     = "pdsoperator@jpl.nasa.gov"
+}

--- a/terraform/opensearch/osi_pipeline/variables.tf
+++ b/terraform/opensearch/osi_pipeline/variables.tf
@@ -8,37 +8,9 @@ variable "pipeline_name" {
   description = "Name of the pipeline (also the cloudwatch log group"
 }
 
-variable "pipeline_role_arn" {
+variable "pipeline_config_yaml_file" {
   type        = string
-  description = "ARN of the role the pipeline assumes to read from source and write to sink. Must have trust relationship w/ pipeline svc."
-}
-
-variable "source_opensearch_url" {
-  type        = string
-  description = "URI of the source opensearch endpoint."
-}
-
-variable "source_opensearch_serverless" {
-  type        = bool
-  description = "Boolean indicating if source is AOSS. Default is true."
-  default     = true
-}
-
-variable "source_batch_size" {
-  type        = string
-  description = "Size of the source batch reads"
-  default     = "1000"
-}
-
-variable "sink_opensearch_url" {
-  type        = string
-  description = "URI of the sink opensearch endpoint."
-}
-
-variable "sink_opensearch_serverless" {
-  type        = bool
-  description = "Boolean indicating if sink is AOSS. Default is false."
-  default     = false
+  description = "Full path to the pipeline config yaml file."
 }
 
 variable "pipeline_max_units" {

--- a/terraform/opensearch/osi_pipeline/variables.tf
+++ b/terraform/opensearch/osi_pipeline/variables.tf
@@ -8,13 +8,18 @@ variable "pipeline_name" {
   description = "Name of the pipeline (also the cloudwatch log group"
 }
 
+variable "pipeline_role_arn" {
+  type        = string
+  description = "ARN of the role the pipeline assumes to read from source and write to sink. Must have trust relationship w/ pipeline svc."
+}
+
 variable "source_opensearch_url" {
   type        = string
   description = "URI of the source opensearch endpoint."
 }
 
 variable "source_opensearch_serverless" {
-  type        = boolean
+  type        = bool
   description = "Boolean indicating if source is AOSS. Default is true."
   default     = true
 }
@@ -22,7 +27,7 @@ variable "source_opensearch_serverless" {
 variable "source_batch_size" {
   type        = string
   description = "Size of the source batch reads"
-  default     = '1000'
+  default     = "1000"
 }
 
 variable "sink_opensearch_url" {
@@ -31,7 +36,7 @@ variable "sink_opensearch_url" {
 }
 
 variable "sink_opensearch_serverless" {
-  type        = boolean
+  type        = bool
   description = "Boolean indicating if sink is AOSS. Default is false."
   default     = false
 }
@@ -41,13 +46,13 @@ variable "pipeline_max_units" {
   description = "Maximum number of pipeline ingestion units."
 }
 
-variable "pipeline_min_units: {
+variable "pipeline_min_units" {
   type        = number
   description = "Minimum number of pipeline ingestion units. Default = 1."
   default     = 1
 }
 
-variable "aws_venue" {
+variable "venue" {
   type        = string
   description = "Tag value of venue"
 }

--- a/terraform/opensearch/provider.tf
+++ b/terraform/opensearch/provider.tf
@@ -1,7 +1,11 @@
-# AWS
-# ===
-#
-# Amazon Web Services: the basics.
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
 
 provider "aws" {
   region = var.aws_region

--- a/terraform/opensearch/provider.tf
+++ b/terraform/opensearch/provider.tf
@@ -1,0 +1,18 @@
+# AWS
+# ===
+#
+# Amazon Web Services: the basics.
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      tenant    = var.tenant
+      venue     = var.venue
+      component = var.component
+      managedBy = var.managedBy
+      cicd      = var.cicd
+    }
+  }
+}

--- a/terraform/opensearch/variables.tf
+++ b/terraform/opensearch/variables.tf
@@ -1,0 +1,73 @@
+variable "region" {
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Name of the provisioned opensearch domain."
+}
+
+variable "data_node_instance_type" {
+  type        = string
+  description = "The instance type for the data nodes."
+  default     = "r6g.xlarge.search"
+}
+
+variable "data_node_count" {
+  type        = number
+  description = "The number of data nodes."
+  default     = 3
+}
+
+variable "master_node_instance_type" {
+  type        = string
+  description = "The instance type for the master nodes."
+  default     = "m6g.large.search"
+}
+
+variable "master_node_count" {
+  type        = number
+  description = "The number of master nodes."
+  default     = 3
+}
+
+variable "ebs_volume_gb" {
+  type        = number
+  description = "The size of the ebs volume per data node, in GB"
+}
+
+variable "venue" {
+  type        = string
+  description = "Value of venue as well as the venue tag"
+}
+
+variable "product_tag_value" {
+  type        = string
+  description = "Value of product tag"
+  default     = "PDS Registry"
+}
+
+variable "tenant_tag_value" {
+  type        = string
+  description = "Value of tenant tag"
+  default     = "en"
+}
+
+variable "component_tag_value" {
+  type        = string
+  description = "Value of component tag"
+  default     = "opensearch"
+}
+
+variable "cicd_tag_value" {
+  type        = string
+  description = "Value of cicd tag"
+  default     = "terraform"
+}
+
+variable "managedBy_tag_value" {
+  type        = string
+  description = "Value of managedBy tag"
+  default     = "pdsoperator@jpl.nasa.gov"
+}

--- a/terraform/opensearch/variables.tf
+++ b/terraform/opensearch/variables.tf
@@ -1,11 +1,13 @@
-variable "region" {
+variable "aws_region" {
   type        = string
+  description = "Effective AWS Region"
   default     = "us-west-2"
 }
 
 variable "domain_name" {
   type        = string
   description = "Name of the provisioned opensearch domain."
+  # "domain_name=pds-mcp-registry-prod-mos" 
 }
 
 variable "data_node_instance_type" {
@@ -35,39 +37,52 @@ variable "master_node_count" {
 variable "ebs_volume_gb" {
   type        = number
   description = "The size of the ebs volume per data node, in GB"
+  # 2560
+}
+
+variable "ebs_volume_type" {
+  type        = string
+  description = "The EBS volume type"
+  default     = "gp3"
+}
+
+variable "n2n_encryption" {
+  type        = bool
+  description = "Node to node encryption"
+  default     = true
+}
+
+variable "encryption_at_rest" {
+  type        = bool
+  description = "Encryption at rest"
+  default     = true
 }
 
 variable "venue" {
   type        = string
-  description = "Value of venue as well as the venue tag"
+  description = "Tag value of venue"
 }
 
-variable "product_tag_value" {
+variable "tenant" {
   type        = string
-  description = "Value of product tag"
-  default     = "PDS Registry"
-}
-
-variable "tenant_tag_value" {
-  type        = string
-  description = "Value of tenant tag"
+  description = "Tag value of tenant"
   default     = "en"
 }
 
-variable "component_tag_value" {
+variable "component" {
   type        = string
-  description = "Value of component tag"
-  default     = "opensearch"
+  description = "Tag value of component"
+  default     = "registry"
 }
 
-variable "cicd_tag_value" {
+variable "cicd" {
   type        = string
-  description = "Value of cicd tag"
+  description = "Tag value of CICD deployment method"
   default     = "terraform"
 }
 
-variable "managedBy_tag_value" {
+variable "managedBy" {
   type        = string
-  description = "Value of managedBy tag"
+  description = "Tag value for owner managing the resource (E.g. for PDS Team we have PDS Team Email Distro)"
   default     = "pdsoperator@jpl.nasa.gov"
 }

--- a/terraform/opensearch/variables.tf
+++ b/terraform/opensearch/variables.tf
@@ -4,6 +4,11 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
+variable "policy_json_file" {
+  type        = string
+  description = "Full path name to access policy json file."
+}
+
 variable "domain_name" {
   type        = string
   description = "Name of the provisioned opensearch domain."


### PR DESCRIPTION
Terraform for provisioned opensearch, to transition from AOSS.

Add main.tf, provider.tf and variables.tf which define the cluster set-up (data nodes, master nodes, ebs) and domain access policy foundation (policies in a separate, JPL internal repo).